### PR TITLE
Support for duckdb 0.2.8 and dbt 0.20.1

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -26,6 +26,28 @@ class DuckDBCredentials(Credentials):
         return ('database', 'schema', 'path')
 
 
+# See https://github.com/jwills/dbt-duckdb/issues/2 for why this wrapper is 
+# necessary. Instead of modeling separate cursors on a shared connection, 
+# duckdb treats the connection as the cursor. Calls to the cursor() API are 
+# supported for compatibility, but duckdb creates a whole new connection 
+# session. This breaks the semantics of temporary tables as used by dbt. If the 
+# underlying semantics of duckdb change, just delete this class and store the 
+# un-wrapped connection handle in the Connection object in 
+# DuckDBConnectionManager.open()
+class DuckDBConnectionWrapper:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def cursor(self):
+        return self._conn
+    
+    def close(self):
+        self._conn.close()
+
+    def rollback(self):
+        self._conn.rollback()
+
+
 class DuckDBConnectionManager(SQLConnectionManager):
     TYPE = 'duckdb'
 
@@ -38,7 +60,7 @@ class DuckDBConnectionManager(SQLConnectionManager):
         credentials = cls.get_credentials(connection.credentials)
         try:
             handle = duckdb.connect(credentials.path, read_only=False)
-            connection.handle = handle
+            connection.handle = DuckDBConnectionWrapper(handle)
             connection.state = 'open'
         except RuntimeError as e:
             logger.debug("Got an error when attempting to open a duckdb "

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -38,14 +38,13 @@ class DuckDBConnectionWrapper:
     def __init__(self, conn):
         self._conn = conn
 
-    def cursor(self):
-        return self._conn
-    
-    def close(self):
-        self._conn.close()
+    # forward along all non-cursor() methods/attribute look ups
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
 
-    def rollback(self):
-        self._conn.rollback()
+    # treat the connection as the cursor
+    def cursor(self):
+        return self
 
 
 class DuckDBConnectionManager(SQLConnectionManager):

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -109,5 +109,5 @@ class DuckDBConnectionManager(SQLConnectionManager):
         return credentials
 
     @classmethod
-    def get_status(cls, cursor):
+    def get_response(cls, cursor):
         return 'OK'

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -14,7 +14,7 @@
 {% macro duckdb__list_schemas(database) -%}
   {% set sql %}
     select schema_name
-    from information_schema_schemata()
+    from information_schema.schemata
   {% endset %}
   {{ return(run_query(sql)) }}
 {% endmacro %}
@@ -22,7 +22,7 @@
 {% macro duckdb__check_schema_exists(information_schema, schema) -%}
   {% set sql -%}
         select count(*)
-        from information_schema_schemata()
+        from information_schema.schemata
         where schema_name='{{ schema }}'
   {%- endset %}
   {{ return(run_query(sql)) }}
@@ -59,7 +59,7 @@
           numeric_precision,
           numeric_scale
 
-      from information_schema_columns()
+      from information_schema.columns
       where table_name = '{{ relation.identifier }}'
         {% if relation.schema %}
         and table_schema = '{{ relation.schema }}'
@@ -82,7 +82,7 @@
         WHEN 'VIEW' THEN 'view'
         WHEN 'LOCAL TEMPORARY' THEN 'table'
         END as type
-    from information_schema_tables()
+    from information_schema.tables
     where table_schema = '{{ schema_relation.schema }}'
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}

--- a/dbt/include/duckdb/macros/catalog.sql
+++ b/dbt/include/duckdb/macros/catalog.sql
@@ -12,7 +12,7 @@
         c.data_type column_type,
         '' as column_comment,
         '' as table_owner
-    FROM information_schema_tables() t JOIN information_schema_columns() c ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+    FROM information_schema.tables t JOIN information_schema.columns c ON t.table_schema = c.table_schema AND t.table_name = c.table_name
     WHERE (
         {%- for schema in schemas -%}
           upper(t.table_schema) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     },
     install_requires=[
         'dbt-core=={}'.format(package_version),
-        'duckdb>=0.2.2',
+        'duckdb>=0.2.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-duckdb"
-package_version = "0.18.1"
+package_version = "0.20.1"
 description = """The duckdb adpter plugin for dbt (data build tool)"""
 
 setup(


### PR DESCRIPTION
This PR addresses #2 and adds support for dbt 0.20.1. 

The full PR was tested with latest pytest_dbt_adapter (0.5.1), but note that the intermediate commit requires the older pytest_dbt_adapter (0.3.0) to work with dbt 0.18.1.