### PR TITLE
Align with minor version of dbt-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.1.1 (Unreleased)
+------------------
+
+- Align with minor version of dbt-core
+
 1.1.0 (2022-04-06)
 ------------------
 
@@ -7,5 +12,5 @@
 1.0.0 (2022-01-10)
 ------------------
 
-- Upgraed to DuckDB 0.3.1
+- Upgraded to DuckDB 0.3.1
 - First basically working version

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is hosted on PyPI, so you should be able to install it and the nece
 
 `pip3 install dbt-duckdb`
 
-The latest supported version targets `dbt-core` 1.0.1 and `duckdb` 0.3.2.
+The latest supported version targets `dbt-core` 1.1.x and `duckdb` 0.3.2.
 
 ### Configuring your profile
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         ]
     },
     install_requires=[
-        "dbt-core~=1.0.0",
+        "dbt-core~=1.1.0",
         "duckdb>=0.3.2",
     ],
 )


### PR DESCRIPTION
Fixes #7

## Test the change

### Install from scratch in a virtual environment

```shell
python3 -m venv env
source env/bin/activate
env/bin/python3 -m pip install --upgrade pip
python -m pip install git+https://github.com/dbeatty10/dbt-duckdb.git@dbeatty_bump_dbt_core_minor_version
source env/bin/activate
dbt --version
```

### Expected output
```shell
Core:
  - installed: 1.1.1
  - latest:    1.1.1 - Up to date!

Plugins:
  - duckdb: 1.1.1 - Up to date!
```