### PR TITLE
Exclude duckdb 0.4.0 from compatible versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
-1.1.1 (Unreleased)
+1.1.2 (Unreleased)
 ------------------
 
 - Align with minor version of dbt-core
+- Constrain range of compatible duckdb versions
+
+1.1.1 (2022-04-06)
+------------------
+
+- Fix typo in package description
 
 1.1.0 (2022-04-06)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     },
     install_requires=[
         "dbt-core~=1.1.0",
-        "duckdb>=0.3.2",
+        "duckdb>=0.3.2,<0.4.0",
     ],
 )


### PR DESCRIPTION
Related to #9

Currently, an install of dbt-duckdb==1.1.1 in a fresh environment will yield versions like this:
- dbt-duckdb-1.1.1
- duckdb-0.4.0

This PR simply constrains the upper bound of duckdb so it will install duckdb-0.3.x instead.