### PR TITLE
Reference count the open connections and close the parent connection when the count is 0

### DIFF
--- a/dbt/adapters/duckdb/__version__.py
+++ b/dbt/adapters/duckdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.2.1"
+version = "1.2.2"


### PR DESCRIPTION
Fixes #17 and bumps the version to `1.2.2` so the fal folks can keep their demo working with multiple threads in DuckDB