### PR TITLE
Generalize the extensions/settings config for DuckDB and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,29 @@ There is also a `database` field defined in the `DuckDBCredentials` class for co
 but it defaults to `main` and setting it to be something else will likely cause strange things to happen that I cannot fully predict,
 so, ya know, don't do that.
 
-As of version 1.2.0, dbt-duckdb also allows you to configure your S3 settings in your credentials, including `s3_region` and
-either `s3_session_token` or `s3_access_key_id` and `s3_secret_access_key`, so that you can use dbt-duckdb to read and transform
-data stored in S3 files. You can also specify an arbitrary number of [DuckDB extensions](https://duckdb.org/docs/extensions/overview) to
-load as part of your dbt-duckdb project using the `extensions: []` credentials field.
+As of version 1.2.3, you can load any supported [DuckDB extensions](https://duckdb.org/docs/extensions/overview) by listing them in
+the `extensions` field in your profile. You can also set any additional [DuckDB configuration options](https://duckdb.org/docs/sql/configuration)
+via the `settings` field, including options that are supported in any loaded extensions. For example, to be able to connect to S3 and read/write
+Parquet files using an AWS access key and secret, your profile would look something like this:
+
+```
+default:
+  outputs:
+    dev:
+      path: /tmp/dbt_test.db
+      schema: analytics
+      type: duckdb
+      threads: 4
+      extensions:
+        - httpfs
+        - parquet
+      settings:
+        s3_region: my-aws-region
+        s3_access_key_id: "{{ env_var('S3_ACCESS_KEY_ID') }}"
+        s3_secret_access_key: "{{ env_var('S3_SECRET_ACCESS_KEY') }}"
+  target: dev
+```
+
 
 ### Developer Workflow
 

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -1,7 +1,7 @@
 import atexit
 import threading
 from contextlib import contextmanager
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import duckdb
 
@@ -25,14 +25,14 @@ class DuckDBCredentials(Credentials):
     schema: str = "main"
     path: str = ":memory:"
 
-    # any extensions we want to install/load (httpfs, json, etc.)
+    # any extensions we want to install and load (httpfs, parquet, etc.)
     extensions: Optional[Tuple[str, ...]] = None
 
-    # for connecting to data in S3 via the httpfs extension
-    s3_region: Optional[str] = None
-    s3_access_key_id: Optional[str] = None
-    s3_secret_access_key: Optional[str] = None
-    s3_session_token: Optional[str] = None
+    # any additional pragmas we want to configure on our DuckDB connections;
+    # a list of the built-in pragmas can be found here:
+    # https://duckdb.org/docs/sql/configuration
+    # (and extensions may add their own pragmas as well)
+    settings: Optional[Dict[str, Any]] = None
 
     @property
     def type(self):
@@ -64,25 +64,14 @@ class DuckDBConnectionWrapper:
     def __init__(self, conn, credentials):
         self._conn = conn
 
-        # Extensions need to be config'd per cursor for reasons
+        # Extensions/settings need to be configured per cursor
         cursor = conn.cursor()
         for ext in credentials.extensions or []:
             cursor.execute(f"LOAD '{ext}'")
-        if credentials.s3_region is not None:
-            cursor.execute("LOAD 'httpfs'")
-            cursor.execute(f"SET s3_region = '{credentials.s3_region}'")
-            if credentials.s3_access_key_id is not None:
-                cursor.execute(
-                    f"SET s3_access_key_id = '{credentials.s3_access_key_id}'"
-                )
-                cursor.execute(
-                    f"SET s3_secret_access_key = '{credentials.s3_secret_access_key}'"
-                )
-            else:
-                cursor.execute(
-                    f"SET s3_session_token = '{credentials.s3_session_token}'"
-                )
-
+        for key, value in (credentials.settings or {}).items():
+            # Okay to set these as strings because DuckDB will cast them
+            # to the correct type
+            cursor.execute(f"SET {key} = '{value}'")
         self._cursor = DuckDBCursorWrapper(cursor)
 
     def __getattr__(self, name):
@@ -117,16 +106,6 @@ class DuckDBConnectionManager(SQLConnectionManager):
                     if credentials.extensions is not None:
                         for extension in credentials.extensions:
                             cls.CONN.execute(f"INSTALL '{extension}'")
-
-                    if credentials.s3_region is not None:
-                        cls.CONN.execute("INSTALL 'httpfs'")
-                        if credentials.s3_session_token is None and (
-                            credentials.s3_access_key_id is None
-                            or credentials.s3_secret_access_key is None
-                        ):
-                            raise dbt.exceptions.RuntimeException(
-                                "You must specify either s3_session_token or s3_access_key_id and s3_secret_access_key"
-                            )
 
                 connection.handle = DuckDBConnectionWrapper(
                     cls.CONN.cursor(), credentials


### PR DESCRIPTION
Instead of special-casing the s3 configuration, let's simply add a `settings` dictionary to the profile where a user can specify any/all configuration settings for their DuckDB connection that they might need; fixes #23 in a more general way.