### PR TITLE
fix: development env requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   hooks:
   -  id: reorder-python-imports
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.10.0
   hooks:
   - id: black
     args:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,13 +5,13 @@
 dbt-tests-adapter==1.3.0
 
 pandas
-black==22.3.0
+black==22.10.0
 bumpversion
 flake8
 flaky
 freezegun==0.3.12
 ipdb
-mypy==0.782
+mypy==0.982
 pip-tools
 pre-commit
 pytest


### PR DESCRIPTION
- bump mypy version in dev-requirements to allow install on ARM-based macs. 
- bump black version in pre-commit to fix override of default_language_version. ref: https://github.com/psf/black/pull/2430