### PR TITLE
fix: concurrency tests

### DIFF
--- a/tests/functional/adapter/test_concurrency.py
+++ b/tests/functional/adapter/test_concurrency.py
@@ -1,40 +1,4 @@
-from dbt.tests.adapter.concurrency.test_concurrency import (
-    BaseConcurrency,
-    seeds__update_csv,
-)
-from dbt.tests.util import (
-    check_relations_equal,
-    check_table_does_not_exist,
-    rm_file,
-    run_dbt,
-    run_dbt_and_capture,
-    write_file,
-)
+from dbt.tests.adapter.concurrency.test_concurrency import TestConcurenncy
 
-
-class TestConcurenncy(BaseConcurrency):
-    def test_concurrency(self, project):
-        run_dbt(["seed", "--select", "seed"])
-        results = run_dbt(["run"], expect_pass=False)
-        assert len(results) == 7
-        check_relations_equal(project.adapter, ["seed", "view_model"])
-        check_relations_equal(project.adapter, ["seed", "dep"])
-        # There is some error in DuckDB causing the missing email identifier. Please ucomment in futer version of dbt
-        # check_relations_equal(project.adapter, ["seed", "table_a"])
-        # check_relations_equal(project.adapter, ["seed", "table_b"])
-        check_table_does_not_exist(project.adapter, "invalid")
-        check_table_does_not_exist(project.adapter, "skip")
-
-        rm_file(project.project_root, "seeds", "seed.csv")
-        write_file(seeds__update_csv, project.project_root, "seeds", "seed.csv")
-
-        results, output = run_dbt_and_capture(["run"], expect_pass=False)
-        assert len(results) == 7
-        check_relations_equal(project.adapter, ["seed", "view_model"])
-        check_relations_equal(project.adapter, ["seed", "dep"])
-        # check_relations_equal(project.adapter, ["seed", "table_a"])
-        # check_relations_equal(project.adapter, ["seed", "table_b"])
-        check_table_does_not_exist(project.adapter, "invalid")
-        check_table_does_not_exist(project.adapter, "skip")
-
-        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 TOTAL=7" in output
+class TestConcurrencyDuckDB(TestConcurenncy):
+    pass


### PR DESCRIPTION
Patch the COLUMNS_EQUAL_SQL template -- used in the adapter method `get_rows_different_sql` -- to not use the same identifiers as the tested relations in the TestConcurrency test cases. This avoids a duckdb binding issue and allows the original test cases to be evaluated.