### PR TITLE
feat: `external_root` profile setting as dir to write external tables when no location is specified

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -111,16 +111,13 @@ class DuckDBConnectionManager(SQLConnectionManager):
                         for extension in credentials.extensions:
                             cls.CONN.execute(f"INSTALL '{extension}'")
 
-                connection.handle = DuckDBConnectionWrapper(
-                    cls.CONN.cursor(), credentials
-                )
+                connection.handle = DuckDBConnectionWrapper(cls.CONN.cursor(), credentials)
                 connection.state = ConnectionState.OPEN
                 cls.CONN_COUNT += 1
 
             except RuntimeError as e:
                 logger.debug(
-                    "Got an error when attempting to open a duckdb "
-                    "database: '{}'".format(e)
+                    "Got an error when attempting to open a duckdb " "database: '{}'".format(e)
                 )
 
                 connection.handle = None
@@ -141,11 +138,7 @@ class DuckDBConnectionManager(SQLConnectionManager):
             credentials = cls.get_credentials(connection.credentials)
             with cls.LOCK:
                 cls.CONN_COUNT -= 1
-                if (
-                    cls.CONN_COUNT == 0
-                    and cls.CONN
-                    and not credentials.path == ":memory:"
-                ):
+                if cls.CONN_COUNT == 0 and cls.CONN and not credentials.path == ":memory:":
                     cls.CONN.close()
                     cls.CONN = None
 

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -34,6 +34,10 @@ class DuckDBAdapter(SQLAdapter):
         except RuntimeException:
             return False
 
+    @available
+    def external_root(self) -> str:
+        return self.config.credentials.external_root
+
     def valid_incremental_strategies(self) -> Sequence[str]:
         """DuckDB does not currently support MERGE statement."""
         return ["append", "delete+insert"]

--- a/dbt/include/duckdb/macros/utils/external_location.sql
+++ b/dbt/include/duckdb/macros/utils/external_location.sql
@@ -1,3 +1,3 @@
 {%- macro external_location(format) -%}
-  {{- this.schema }}/{{ this.identifier}}.{{ format }}
+  {{- adapter.external_root() }}/{{ this.identifier }}.{{ format }}
 {%- endmacro -%}

--- a/tests/functional/adapter/test_concurrency.py
+++ b/tests/functional/adapter/test_concurrency.py
@@ -1,4 +1,5 @@
 from dbt.tests.adapter.concurrency.test_concurrency import TestConcurenncy
 
+
 class TestConcurrencyDuckDB(TestConcurenncy):
     pass

--- a/tests/functional/adapter/test_external.py
+++ b/tests/functional/adapter/test_external.py
@@ -96,9 +96,7 @@ class BaseExternalMaterializations:
 
         # base table rowcount
         relation = relation_from_name(project.adapter, "base")
-        result = project.run_sql(
-            f"select count(*) as num_rows from {relation}", fetch="one"
-        )
+        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
         assert result[0] == 10
 
         # relations_equal

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -71,9 +71,7 @@ def project_from_dict(project, profile, packages=None, selectors=None, cli_vars=
     return partial.render(renderer)
 
 
-def config_from_parts_or_dicts(
-    project, profile, packages=None, selectors=None, cli_vars="{}"
-):
+def config_from_parts_or_dicts(project, profile, packages=None, selectors=None, cli_vars="{}"):
     from copy import deepcopy
 
     from dbt.config import Profile, Project, RuntimeConfig


### PR DESCRIPTION
Per a discussion on #19, I'm adding an `external_root` to the top-level `duckdb` profile object (specified via the `Credentials` class) which defaults to `.` (the current working directory) but can be overridden to make it easy to specify a directory or S3 bucket where the parquet/csv files for any `external` materialization should be written to in the form of `{{ external_root }}/{{ identifier }}.{{ format }}` per the `external_location` macro.