### PR TITLE
Allow dbt-duckdb to work with versions after 0.5.0, including the new 0.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     - "--target-version=py38"
     - "--check"
     - "--diff"
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 4.0.1
   hooks:
   - id: flake8

--- a/dbt/adapters/duckdb/__version__.py
+++ b/dbt/adapters/duckdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.3.1"
+version = "1.3.2"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~=1.3.0",
-        "duckdb~=0.5.0",
+        "duckdb>=0.5.0",
     ],
     extras_require={
         "glue": ["boto3", "mypy-boto3-glue"],


### PR DESCRIPTION
Fixes #59 