### PR TITLE
Use an importlib-based approach to loading and executing dbt Python models

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,3 +1,4 @@
+import os
 import importlib.util
 import tempfile
 from typing import List
@@ -104,7 +105,7 @@ class DuckDBAdapter(SQLAdapter):
         except Exception as err:
             raise RuntimeException(f"Python model failed:\n" f"{err}")
         finally:
-            mod_file.close()
+            os.unlink(mod_file.name)
         return AdapterResponse(_message="OK")
 
     def get_rows_different_sql(

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,5 +1,5 @@
-import os
 import importlib.util
+import os
 import tempfile
 from typing import List
 from typing import Optional
@@ -95,8 +95,17 @@ class DuckDBAdapter(SQLAdapter):
         mod_file.close()
         try:
             spec = importlib.util.spec_from_file_location(identifier, mod_file.name)
+            if not spec:
+                raise RuntimeException(
+                    "Failed to load python model as module: {}".format(identifier)
+                )
             module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+            if spec.loader:
+                spec.loader.exec_module(module)
+            else:
+                raise RuntimeException(
+                    "Python module spec is missing loader: {}".format(identifier)
+                )
 
             # Do the actual work to run the code here
             dbt = module.dbtObj(load_df_function)

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -9,15 +9,19 @@ from dbt.tests.adapter.python_model.test_python_model import (
 )
 
 basic_python_template = """
+import pandas as pd
+
 def model(dbt, _):
     dbt.config(
         materialized='table',
     )
+    pdf = pd.DataFrame()
     df =  dbt.ref("my_sql_model")
     df2 = dbt.source('test_source', 'test_table')
     df = df.limit(2)
     return df{extension}
 """
+
 
 class TestBasePythonModelDuckDBPyRelation(BasePythonModelTests):
     @pytest.fixture(scope="class")
@@ -28,6 +32,7 @@ class TestBasePythonModelDuckDBPyRelation(BasePythonModelTests):
             "my_python_model.py": basic_python_template.format(extension=""),
             "second_sql_model.sql": second_sql,
         }
+
 
 class TestBasePythonModelPandasDF(BasePythonModelTests):
     @pytest.fixture(scope="class")


### PR DESCRIPTION
Fixes #63 

This ended up being kind of neat and I think better than the `exec` based approach: the idea here is that we treat each dbt Python model as its own Python module that we dynamically load and execute using the methods inside of `importlib.util`. Once that is done, we can call the `dbtObj`, `model`, and `materialize` functions that we declared inside of the `.py` file as if they were simply functions on the module, so we get:

a) Working top-level imports (to fix #63)
b) Isolation of the code in each model file in a way that we don't pollute the globals

...which is pretty cool!