### PR TITLE
Work around pandas dependency on parameter bindings that feature datetime instances

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -5,6 +5,8 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 
+import agate
+
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.base.column import Column
 from dbt.adapters.base.meta import available
@@ -28,6 +30,21 @@ class DuckDBAdapter(SQLAdapter):
     @classmethod
     def is_cancelable(cls) -> bool:
         return False
+
+    @available
+    def convert_datetimes_to_strs(self, table: agate.Table) -> agate.Table:
+        for column in table.columns:
+            if isinstance(column.data_type, agate.DateTime):
+                table = table.compute(
+                    [
+                        (
+                            column.name,
+                            agate.Formula(agate.Text(), lambda row: str(row[column.name])),
+                        )
+                    ],
+                    replace=True,
+                )
+        return table
 
     @available
     def location_exists(self, location: str) -> bool:

--- a/dbt/include/duckdb/macros/seed.sql
+++ b/dbt/include/duckdb/macros/seed.sql
@@ -1,4 +1,5 @@
 {% macro duckdb_load_csv_rows(model, batch_size, agate_table) %}
+    {% set agate_table = adapter.convert_datetimes_to_strs(agate_table) %}
     {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}
     {% set bindings = [] %}
 


### PR DESCRIPTION
There's an implicit dependency on `pandas` in `duckdb` when you are using parameter bindings that are `datetime` instances on an execute call; the details of the bug (which is now fixed in duckdb master) are here: https://github.com/duckdb/duckdb/issues/5577

I'd like to get around this in the meantime by adding a hack to the `load_csv_rows` method that dbt-duckdb uses to convert any `agate.DateTime` columns to be strings instead of `datetime` instances; I did some manual testing to verify that this fixed the issue.