### PR TITLE
ext_location: str.format with schema

### DIFF
--- a/dbt/adapters/duckdb/relation.py
+++ b/dbt/adapters/duckdb/relation.py
@@ -27,11 +27,13 @@ class DuckDBRelation(BaseRelation):
             ext_location = source.source_meta["external_location"]
 
         if ext_location:
-            # Call str.format with the name and identifier for the source so that they
+            # Call str.format with the schema, name and identifier for the source so that they
             # can be injected into the string; this helps reduce boilerplate when all
             # of the tables in the source have a similar location based on their name
             # and/or identifier.
-            ext_location = ext_location.format(name=source.name, identifier=source.identifier)
+            ext_location = ext_location.format(
+                schema=source.schema, name=source.name, identifier=source.identifier
+            )
             # If it's a function call or already has single quotes, don't add them
             if "(" not in ext_location and not ext_location.startswith("'"):
                 ext_location = f"'{ext_location}'"


### PR DESCRIPTION
I've been using this recently and found myself putting some vars in dbt_project.yml when I think just using the schema name similar to name or identifier probably makes more sense. 

Let me know if there is a different approach I should be taking here! I'm certainly more used to consuming dbt than contributing to adapters etc. 