### PR TITLE
Experimental support for running dbt-duckdb against a Buena Vista-based proxy server

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -47,6 +47,13 @@ class DuckDBAdapter(SQLAdapter):
         return table
 
     @available
+    def paramformat(self):
+        if self.config.credentials.host:
+            return "%s"
+        else:
+            return "?"
+
+    @available
     def location_exists(self, location: str) -> bool:
         try:
             self.execute(

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -96,7 +96,7 @@ class DuckDBAdapter(SQLAdapter):
         connection = self.connections.get_if_exists()
         if not connection:
             connection = self.connections.get_thread_connection()
-        con = connection.handle._conn
+        con = connection.handle
 
         def load_df_function(table_name: str):
             """

--- a/dbt/include/duckdb/macros/seed.sql
+++ b/dbt/include/duckdb/macros/seed.sql
@@ -16,7 +16,7 @@
             insert into {{ this.render() }} ({{ cols_sql }}) values
             {% for row in chunk -%}
                 ({%- for column in agate_table.column_names -%}
-                    ?
+                    {{ adapter.paramformat() }}
                     {%- if not loop.last%},{%- endif %}
                 {%- endfor -%})
                 {%- if not loop.last%},{%- endif %}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,7 @@ ipdb
 mypy==0.991
 pip-tools
 pre-commit
+psycopg2-binary
 pytest
 pytest-dotenv
 pytest-logbook

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
     ],
     extras_require={
         "glue": ["boto3", "mypy-boto3-glue"],
+        "server": ["psycopg2"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     ],
     extras_require={
         "glue": ["boto3", "mypy-boto3-glue"],
-        "server": ["psycopg2"],
+        "server": ["psycopg2-binary"],
     },
 )


### PR DESCRIPTION
One of my fun hobby projects is a pure-Python Postgres proxy server called Buena Vista (BV) that I have written a DuckDB-based impl for: https://github.com/jwills/buenavista/blob/main/examples/duckdb_server.py

I started working on it because a) I have always wanted something like it as a way to play with SQL query rewriting in ways that a regular database won't let you do and b) because I realized in doing dbt-duckdb development work that it's actually _really_ convenient to be able to simultaneously query your database from one place (using e.g. DBeaver or pgcli or whatever your tool of choice is) while _also_ running dbt models against your database in another terminal/shell. Since DuckDB (currently) has a rule that if one process has write privileges to a DuckDB file, then no other process is allowed to talk to that file, I needed a way for both dbt _and_ my query tool of choice to connect to the same DuckDB database file and do work against it-- ya know, like, the way a database usually works.

This PR creates a way to specify in the credentials for the `dbt-duckdb` target that the adapter should connect to a BV server instead of opening the DuckDB file on the path directly. My thinking here is that for the `dev` target, someone could use a BV server to do their development work, but a `prod` (or whatever) target would just write the DB file directly (so no proxy server, just run as normal against the DuckDB file in process.)

Note that I am using `psycopg2` as the driver here; I tested out a lot of them but I chose `psycopg2` b/c of its popularity, the fact that dbt uses it for `dbt-postgres` already, and the fact that it does all of the parameter bindings for prepared statements locally which helps a lot with the performance and simplicity of the BV implementation.

There are a few questions that I've been thinking about that I would like some feedback on:

1) Right now, specifying the `host` and `port` arguments in the target config means that we will completely ignore the `path` argument and just talk to the BV server directly (which right now, is configured to load a DuckDB file of its own when it is initialized)-- is that the right thing to do? Or should we keep the `path` arg in play and somehow communicate the path to the BV server so that it opens the DuckDB file at that path as its primary database (if it hasn't done so already?) That might involve refactoring the BV server a bit so that it could support having connections to multiple DuckDB files at once, which doesn't seem so bad and might actually be good?

2) The BV server does not currently support Python models, but since it's a Python service itself, I _think_ it would be relatively straightforward to do so; the main question is how we would communicate to the BV server that the "query" it's getting is a python script that it needs to execute instead of a SQL query? Should it be a separate/dedicated endpoint on the BV server itself? Should it be a "mode" that you can put the Postgres connection into so that it interprets the query payload it receives as Python instead of SQL?

3) Is there other stuff I should have thought about but haven't yet?
