### PR TITLE
Fix python models not inheriting AWS credentials

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -96,7 +96,7 @@ class DuckDBAdapter(SQLAdapter):
         connection = self.connections.get_if_exists()
         if not connection:
             connection = self.connections.get_thread_connection()
-        con = connection.handle._conn
+        con = connection.handle.cursor()
 
         def load_df_function(table_name: str):
             """


### PR DESCRIPTION
Solution: use the cursor which has the credentials set, instead of the raw connection.