### PR TITLE
Register views for upstream external models.

### DIFF
--- a/dbt/include/duckdb/macros/materializations/external.sql
+++ b/dbt/include/duckdb/macros/materializations/external.sql
@@ -1,7 +1,7 @@
 {% materialization external, adapter="duckdb", supported_languages=['sql', 'python'] %}
 
   {%- set format = render(config.get('format', default='parquet')) -%}
-  {%- set location = render(config.get('location', default=external_location(format))) -%}
+  {%- set location = render(config.get('location', default=external_location(this, format))) -%}
   {%- set delimiter = render(config.get('delimiter', default=',')) -%}
   {%- set glue_register = config.get('glue_register', default=false) -%}
   {%- set glue_database = render(config.get('glue_database', default='default')) -%}
@@ -34,6 +34,9 @@
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
   {{ drop_relation_if_exists(preexisting_temp_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  -- Register upstream external materialized models as views
+  {%- do register_external_upstream() -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -26,6 +26,9 @@
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
+  -- Register upstream external materialized models as views
+  {%- do register_external_upstream() -%}
+
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:

--- a/dbt/include/duckdb/macros/materializations/table.sql
+++ b/dbt/include/duckdb/macros/materializations/table.sql
@@ -23,6 +23,9 @@
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
+  -- Register upstream external materialized models as views
+  {%- do register_external_upstream() -%}
+
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:

--- a/dbt/include/duckdb/macros/utils/external_location.sql
+++ b/dbt/include/duckdb/macros/utils/external_location.sql
@@ -1,3 +1,3 @@
-{%- macro external_location(format) -%}
-  {{- adapter.external_root() }}/{{ this.identifier }}.{{ format }}
+{%- macro external_location(relation, format) -%}
+  {{- adapter.external_root() }}/{{ relation.identifier }}.{{ format }}
 {%- endmacro -%}

--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -1,0 +1,25 @@
+{%- macro register_external_upstream() -%}
+{% if execute %}
+  {% for node in model['depends_on']['nodes'] %}
+    {% set upstream = graph.nodes.get(node) %}
+    {% if upstream %}
+      {%- set upstream_rel = api.Relation.create(
+        database=upstream['database'],
+        schema=upstream['schema'],
+        identifier=upstream['alias']
+      ) -%}
+      {%- if upstream.config.materialized=='external' and not load_cached_relation(upstream_rel) -%}
+        {%- set format = render(upstream.config.get('format', 'parquet')) -%}
+        {%- set upstream_location = render(
+            upstream.config.get('location', external_location(upstream_rel, format)))
+        -%}
+        {% call statement('main', language='sql') -%}
+          create or replace view {{ upstream_rel.include(database=False) }} as (
+            select * from '{{ upstream_location }}'
+          );
+        {%- endcall %}
+      {%- endif %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{%- endmacro -%}

--- a/tests/functional/adapter/test_external_rematerialize.py
+++ b/tests/functional/adapter/test_external_rematerialize.py
@@ -1,0 +1,47 @@
+import pytest
+from dbt.tests.util import run_dbt
+from dbt.adapters.duckdb import DuckDBConnectionManager
+
+upstream_model_sql = """
+select range from range(3)
+"""
+
+
+downstream_model_sql = """
+select range * 2 from {{ ref('upstream_model') }}
+"""
+
+# class must begin with 'Test'
+class TestRematerializeDownstreamExternalModel:
+    """
+    External models should load in dependencies when they exist.
+
+    We test that after materializing upstream and downstream models, we can
+    materialize the downstream model by itself, even if we are using an
+    in-memory database.
+    """
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {
+            "type": "duckdb",
+            "path": ":memory:",
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "base", "models": {"+materialized": "external"}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "upstream_model.sql": upstream_model_sql,
+            "downstream_model.sql": downstream_model_sql,
+        }
+
+    def test_run(self, project):
+        run_dbt(["run"])
+
+        # Force close the :memory: connection
+        DuckDBConnectionManager.close_all_connections()
+        run_dbt(["run", "--select", "downstream_model"])


### PR DESCRIPTION
Closes https://github.com/jwills/dbt-duckdb/issues/79

This requires a (minor) breaking change:
* The `external_location(format)` macro is now `external_location(this, format)`.

If one is overriding this macro in their dbt project, they will just have to convert their macro to the new signature.

This change is needed in order to determine the external location of upstream models, not just the current model. We explicitly shadow `this` to prevent confusion between the current model and the upstream model when specifying the location.
