### PR TITLE
Load upstream external models with a macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ default:
   target: dev
 ```
 
+### Re-running external models with an in-memory version of dbt-duckdb
+When using `:memory:` as the DuckDB database, subsequent dbt runs can fail when selecting a subset of models that depend on external tables. This is because external Parquet or CSV files are only registered as  DuckDB views when they are created, not when they are referenced. To overcome this issue we have provided the `register_upstream_external_models` macro that can be triggered at the beginning of a run. To enable this automatic registration, place the following in your `dbt_project.yml` file:
+
+```yaml
+on-run-start:
+  - "{{ register_upstream_external_models() }}"
+```
+
+### External sources
+
 `dbt-duckdb` also includes support for referencing external CSV and Parquet files as dbt `source`s via the `external_location`
 meta option:
 

--- a/dbt/include/duckdb/macros/materializations/external.sql
+++ b/dbt/include/duckdb/macros/materializations/external.sql
@@ -35,9 +35,6 @@
   {{ drop_relation_if_exists(preexisting_temp_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
-  -- Register upstream external materialized models as views
-  {%- do register_external_upstream() -%}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -26,9 +26,6 @@
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
-  -- Register upstream external materialized models as views
-  {%- do register_external_upstream() -%}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:

--- a/dbt/include/duckdb/macros/materializations/table.sql
+++ b/dbt/include/duckdb/macros/materializations/table.sql
@@ -23,9 +23,6 @@
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
-  -- Register upstream external materialized models as views
-  {%- do register_external_upstream() -%}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:

--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -1,18 +1,31 @@
-{%- macro register_external_upstream() -%}
+{%- macro register_upstream_external_models() -%}
 {% if execute %}
-  {% for node in model['depends_on']['nodes'] %}
-    {% set upstream = graph.nodes.get(node) %}
-    {% if upstream %}
-      {%- set upstream_rel = api.Relation.create(
-        database=upstream['database'],
-        schema=upstream['schema'],
-        identifier=upstream['alias']
-      ) -%}
-      {%- if upstream.config.materialized=='external' and not load_cached_relation(upstream_rel) -%}
+{% set upstream_nodes = {} %}
+{% set upstream_schemas = {} %}
+{% for node in selected_resources %}
+  {% for upstream_node in graph['nodes'][node]['depends_on']['nodes'] %}
+    {% if upstream_node not in upstream_nodes and upstream_node not in selected_resources %}
+      {% do upstream_nodes.update({upstream_node: None}) %}
+      {% set upstream = graph['nodes'].get(upstream_node) %}
+      {% if upstream
+         and upstream.resource_type in ('model', 'seed')
+         and upstream.config.materialized=='external'
+      %}
+        {%- set upstream_rel = api.Relation.create(
+          database=upstream['database'],
+          schema=upstream['schema'],
+          identifier=upstream['alias']
+        ) -%}
         {%- set format = render(upstream.config.get('format', 'parquet')) -%}
         {%- set upstream_location = render(
             upstream.config.get('location', external_location(upstream_rel, format)))
         -%}
+        {% if upstream_rel.schema not in upstream_schemas %}
+          {% call statement('main', language='sql') -%}
+            create schema if not exists {{ upstream_rel.schema }}
+          {%- endcall %}
+          {% do upstream_schemas.update({upstream_rel.schema: None}) %}
+        {% endif %}
         {% call statement('main', language='sql') -%}
           create or replace view {{ upstream_rel.include(database=False) }} as (
             select * from '{{ upstream_location }}'
@@ -21,5 +34,6 @@
       {%- endif %}
     {% endif %}
   {% endfor %}
+{% endfor %}
 {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
https://github.com/jwills/dbt-duckdb/pull/80 has the unfortunate side-effect of causing a write-write catalog conflict whenever two models have the same upstream external model and threads > 1.

We solve this by providing a macro to be used as an `on-run-start` hook, that registers the needed upstream external models based on the `selected_resources`.

Unfortunately, adapters appear unable to automatically add any on-run-start hooks, so we provide information about when to enable it in the README.