### PR TITLE
Prefer pyarrow instead of pandas for python model materialization

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -68,13 +68,16 @@ def materialize(df, con):
         pyarrow_available = False
 
     if isinstance(df, duckdb.DuckDBPyRelation):
-        if pandas_available:
-            df = df.df()
-        elif pyarrow_available:
+        if pyarrow_available:
             df = df.arrow()
+        elif pandas_available:
+            df = df.df()
         else:
             raise Exception("No pandas or pyarrow available to materialize DuckDBPyRelation")
-    elif not (isinstance(df, pandas.DataFrame) or isinstance(df, pyarrow.Table)):
+    elif not (
+      (pandas_available and isinstance(df, pandas.DataFrame))
+      or (pyarrow_available and isinstance(df, pyarrow.Table))
+    ):
         raise Exception( str(type(df)) + " is not a supported type for dbt Python materialization")
 
     con.execute('create table {{ relation.include(database=False) }} as select * from df')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ dbt-tests-adapter==1.4.1
 boto3
 mypy-boto3-glue
 pandas
+pyarrow
 black==22.12.0
 bumpversion
 flake8

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -78,18 +78,13 @@ def model(dbt, con):
 """
 
 
-# class must begin with 'Test'
 class TestEmptyPythonModel:
     """
-    This test ensures that Python models are created with the correct schema even when empty.
-
-    Pandas dataframes are not strongly typed. DuckDB uses inference for strings (objects) 
-    to determine the actual types when converting from Pandas. For an empty dataframe this 
-    will incorrectly result in the default (INTEGER) type. Previously, Python models by 
-    default were materialized using Pandas dataframes, so this test ensures `pyarrow` is the 
-    first choice for materialization.
+    This test ensures that Python models returning a DuckDBPyRelation are materialized
+    with the correct schema, even when empty. I.e. ensure pyarrow is being used instead
+    of pandas.
     """
-    
+
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -105,4 +100,4 @@ class TestEmptyPythonModel:
             """,
             fetch="all",
         )
-        assert result == [('a', 'VARCHAR'), ('b', 'BOOLEAN')]
+        assert result == [("a", "VARCHAR"), ("b", "BOOLEAN")]

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -68,8 +68,6 @@ class TestBasePythonIncremental(BasePythonIncrementalTests):
 
 
 empty_upstream_model_python = """
-import duckdb
-
 def model(dbt, con):
     dbt.config(
         materialized='table',


### PR DESCRIPTION
Currently, Python models returning a DuckDBPyRelation are materialized using `pandas` even if `pyarrow` is available. Because Pandas dataframes are not strongly typed, DuckDB uses inference for objects to determine the actual types when loading a dataframe. This causes empty VARCHAR cols to be incorrectly materialized with the default (INTEGER) type.

We switch the order to prefer `pyarrow` when available.