### PR TITLE
Allow flexible configurability of extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IntelliJ project files
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dbt/adapters/duckdb/extension.py
+++ b/dbt/adapters/duckdb/extension.py
@@ -1,0 +1,85 @@
+from abc import ABC
+from abc import abstractmethod
+from typing import Dict
+
+
+class BaseExtension(ABC):
+    def __init__(self, name, connection, params=None):
+        self.name = name
+        self.connection = connection
+        self.params = params
+
+    def install(self):
+        self.connection.execute(f"INSTALL '{self.name}'")
+
+    def load(self):
+        self.connection.execute(f"LOAD '{self.name}'")
+
+    @abstractmethod
+    def configure(self):
+        pass
+
+
+class HttpFsExtension(BaseExtension):
+    def configure(self):
+        pass
+
+
+class S3Extension(BaseExtension):
+    def configure(self):
+        pass
+
+
+class ParquetExtension(BaseExtension):
+    def configure(self):
+        pass
+
+
+class SQLiteExtension(BaseExtension):
+    def configure(self):
+        is_attached = self.connection.execute(
+            "select * from information_schema.tables where table_name = '_SqliteDatabaseProperties'"
+        ).fetchone()
+        if not is_attached:
+            self.connection.execute(f"CALL sqlite_attach('{self.params['path']}')")
+
+
+class PostgresExtension(BaseExtension):
+    def configure(self):
+        self.connection.execute(
+            f"CALL postgres_attach('dbname={self.params['db_name']}"
+            f"user={self.params['user']} host={self.params['host']}',"
+            f"source_schema='{self.params['source_schema']}',"
+            f"sink_schema='{self.params['sink_schema']}')"
+        )
+
+
+class ExtensionFactory:
+    EXTENSIONS = {
+        "sqlite": SQLiteExtension,
+        "postgres": PostgresExtension,
+        "httpfs": HttpFsExtension,
+        "s3": S3Extension,
+        "parquet": ParquetExtension,
+    }
+
+    @staticmethod
+    def register_extension(extension_info, connection):
+        """
+        Initialize an extension object based on the extension name and parameters. The extension_info can be a simple
+        string or a dictionary with the extension name as the key and the parameters as the value.
+        """
+        if isinstance(extension_info, Dict):
+            extension_name = list(extension_info.keys())[0]
+            extension_params = extension_info[extension_name]
+        else:
+            extension_name = extension_info
+            extension_params = {}
+        if extension_name not in ExtensionFactory.EXTENSIONS:
+            raise ValueError(
+                f"Extension type {extension_name} not supported."
+                f"Supported extensions are: {ExtensionFactory.EXTENSIONS.keys()}"
+            )
+        return ExtensionFactory.EXTENSIONS[extension_name](
+            extension_name, connection, extension_params
+        )


### PR DESCRIPTION
I was playing around with the SQLite extension which requires to an extra function call to attach the SQLite database so the tables are available in DuckDB as views. This[ function call ](https://duckdb.org/docs/extensions/sqlite_scanner#usage) requires the path of the SQLite database as a parameter which in the current version cannot be added to the profile. 

This prompted a little refactoring to allow flexible definitions & configuration of extensions.

Example profile with extensions that allow configuration:

```yaml
default:
  outputs:
   dev:
     type: duckdb
     path: /tmp/dbt.duckdb
     extensions:
      - parquet
      - sqlite:
          path: /path/to/sqlite.db
      - postgres:
          db_name: postgres
          host: localhost
          user: postgres
          source_schema: public
          sink_schema: abc
  target: dev
```

Factoring out the extensions into a separate class would allow validations to be created and other extension-specific functionality.

I'm just getting started with DuckDB and dbt adapters in general so would love some guidance on how this could be better handled! If we align on a direction I'll add tests & docs.