### PR TITLE
Getting the code ready for DuckDB 0.7.0 and dbt 1.4.0

### DIFF
--- a/dbt/adapters/duckdb/__version__.py
+++ b/dbt/adapters/duckdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.3.3"
+version = "1.4.0"

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -49,7 +49,7 @@ class DuckDBCredentials(Credentials):
     def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
         data = super().__pre_deserialize__(data)
         path = data["path"]
-        if duckdb.__version__ >= '0.7.0':
+        if duckdb.__version__ >= "0.7.0":
             if path == ":memory:":
                 data["database"] = "memory"
             else:

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -1,4 +1,5 @@
 import atexit
+import os
 import threading
 import time
 from contextlib import contextmanager
@@ -43,6 +44,17 @@ class DuckDBCredentials(Credentials):
     # identify whether to use the default credential provider chain for AWS/GCloud
     # instead of statically defined environment variables
     use_credential_provider: Optional[str] = None
+
+    @classmethod
+    def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
+        data = super().__pre_deserialize__(data)
+        path = data["path"]
+        if duckdb.__version__ >= '0.7.0':
+            if path == ":memory:":
+                data["database"] = "memory"
+            else:
+                data["database"] = os.path.splitext(os.path.basename(path))[0]
+        return data
 
     @property
     def type(self):

--- a/dbt/include/duckdb/macros/catalog.sql
+++ b/dbt/include/duckdb/macros/catalog.sql
@@ -2,7 +2,7 @@
 {% macro duckdb__get_catalog(information_schema, schemas) -%}
   {%- call statement('catalog', fetch_result=True) -%}
     select
-        'main' as table_database,
+        '{{ database }}' as table_database,
         t.table_schema,
         t.table_name,
         t.table_type,

--- a/tests/functional/adapter/test_ephemeral.py
+++ b/tests/functional/adapter/test_ephemeral.py
@@ -69,7 +69,7 @@ class TestEphemeralNested(BaseEphemeral):
         expected_sql = (
             'create view "test_test_ephemeral"."root_view__dbt_tmp" as ('
             "with __dbt__cte__ephemeral_level_two as ("
-            'select * from "main"."test_test_ephemeral"."source_table"'
+            'select * from "dbt_test"."test_test_ephemeral"."source_table"'
             "),  __dbt__cte__ephemeral as ("
             "select * from __dbt__cte__ephemeral_level_two"
             ")select * from __dbt__cte__ephemeral"


### PR DESCRIPTION
In the world of attachable databases, the default `database` for a DuckDB is now either:

1) `memory`, for an in-memory database, or
2) the basename of the DuckDB file, stripped of its extension.

These changes make the dbt-duckdb integration tests pass against DuckDB 0.7.0.