### PR TITLE
WIP: Add ATTACH support for dbt-duckdb and DuckDB 0.7.0

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -29,7 +29,7 @@ class Attachment:
     path: str
 
     # The type of the attached database (defaults to duckdb, but may be supported by an extension)
-    type: str = "duckdb"
+    type: Optional[str] = None
 
     # An optional alias for the attached database
     alias: Optional[str] = None
@@ -43,7 +43,7 @@ class Attachment:
             base += f" AS {self.alias}"
         options = []
         if self.type:
-            options.append("TYPE {self.type}")
+            options.append(f"TYPE {self.type}")
         if self.read_only:
             options.append("READ_ONLY")
         if options:

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -47,8 +47,8 @@ class Attachment:
         if self.read_only:
             options.append("READ_ONLY")
         if options:
-            joined = ",".join(options)
-            base += f"({joined})"
+            joined = ", ".join(options)
+            base += f" ({joined})"
         return base
 
 

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -6,6 +6,7 @@ from typing import Optional
 from typing import Sequence
 
 import agate
+import duckdb
 
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.base.column import Column
@@ -79,6 +80,10 @@ class DuckDBAdapter(SQLAdapter):
     @available
     def external_root(self) -> str:
         return self.config.credentials.external_root
+
+    @available
+    def use_database(self) -> bool:
+        return duckdb.__version__ >= "0.7.0"
 
     def valid_incremental_strategies(self) -> Sequence[str]:
         """DuckDB does not currently support MERGE statement."""

--- a/dbt/include/duckdb/macros/materializations/external.sql
+++ b/dbt/include/duckdb/macros/materializations/external.sql
@@ -49,7 +49,7 @@
   {{ write_to_file(temp_relation, location, format, delimiter) }}
   -- create a view on top of the location
   {% call statement('main', language='sql') -%}
-    create or replace view {{ intermediate_relation.include(database=False) }} as (
+    create or replace view {{ intermediate_relation.include(database=adapter.use_database()) }} as (
         select * from '{{ location }}'
     );
   {%- endcall %}

--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -27,7 +27,7 @@
           {% do upstream_schemas.update({upstream_rel.schema: None}) %}
         {% endif %}
         {% call statement('main', language='sql') -%}
-          create or replace view {{ upstream_rel.include(database=False) }} as (
+          create or replace view {{ upstream_rel.include(database=adapter.use_database()) }} as (
             select * from '{{ upstream_location }}'
           );
         {%- endcall %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,5 +12,6 @@ def dbt_profile_target():
     return {
         "type": "duckdb",
         "threads": 1,
-        "path": "/tmp/dbt_test.duckdb",
+        "path": ":memory:",
+        "attach": [{"path": "/tmp/dbt_test.duckdb"}],
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,5 +13,4 @@ def dbt_profile_target():
         "type": "duckdb",
         "threads": 1,
         "path": ":memory:",
-        "attach": [{"path": "/tmp/dbt_test.duckdb"}],
     }

--- a/tests/functional/adapter/test_attach.py
+++ b/tests/functional/adapter/test_attach.py
@@ -1,0 +1,76 @@
+import os
+
+import duckdb
+import pytest
+import yaml
+
+from dbt.tests.util import run_dbt
+
+sources_schema_yml = """version: 2
+sources:
+  - name: attached_source
+    database: attach_test
+    schema: analytics
+    tables:
+      - name: attached_table
+        description: "An attached table"
+        columns:
+          - name: id
+            description: "An id"
+            tests:
+              - unique
+              - not_null
+"""
+
+models_source_model_sql = """select * from {{ source('attached_source', 'attached_table') }}
+"""
+
+models_target_model_sql = """
+    {{ config(materialized='table', database='attach_test') }}
+    SELECT * FROM {{ ref('source_model') }}
+"""
+
+
+class TestAttachedDatabase:
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self):
+        db = duckdb.connect("/tmp/attach_test.duckdb")
+        db.execute("CREATE SCHEMA analytics")
+        db.execute("CREATE TABLE analytics.attached_table AS SELECT 1 as id")
+        db.commit()
+        db.close()
+
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": ":memory:",
+                        "attach": [{"path": "/tmp/attach_test.duckdb"}],
+                    }
+                },
+                "target": "dev",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": sources_schema_yml,
+            "source_model.sql": models_source_model_sql,
+            "target_model.sql": models_target_model_sql,
+        }
+
+    def test_attached_databases(self, project):
+        try:
+            results = run_dbt()
+            assert len(results) == 2
+
+            test_results = run_dbt(["test"])
+            assert len(test_results) == 2
+
+            db = duckdb.connect("/tmp/attach_test.duckdb")
+            ret = db.execute(f"SELECT * FROM target_model").fetchall()
+            assert ret[0][0] == 1
+        finally:
+            os.unlink("/tmp/attach_test.duckdb")

--- a/tests/functional/adapter/test_ephemeral.py
+++ b/tests/functional/adapter/test_ephemeral.py
@@ -31,7 +31,7 @@ class TestEphemeralMulti(BaseEphemeralMulti):
 
         sql_file = re.sub(r"\d+", "", sql_file)
         expected_sql = (
-            'create view "test_test_ephemeral"."double_dependent__dbt_tmp" as ('
+            'create view "memory"."test_test_ephemeral"."double_dependent__dbt_tmp" as ('
             "with __dbt__cte__base as ("
             "select * from test_test_ephemeral.seed"
             "),  __dbt__cte__base_copy as ("
@@ -67,9 +67,9 @@ class TestEphemeralNested(BaseEphemeral):
 
         sql_file = re.sub(r"\d+", "", sql_file)
         expected_sql = (
-            'create view "test_test_ephemeral"."root_view__dbt_tmp" as ('
+            'create view "memory"."test_test_ephemeral"."root_view__dbt_tmp" as ('
             "with __dbt__cte__ephemeral_level_two as ("
-            'select * from "dbt_test"."test_test_ephemeral"."source_table"'
+            'select * from "memory"."test_test_ephemeral"."source_table"'
             "),  __dbt__cte__ephemeral as ("
             "select * from __dbt__cte__ephemeral_level_two"
             ")select * from __dbt__cte__ephemeral"

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -15,7 +15,7 @@ class TestDuckDBAdapter(unittest.TestCase):
             "outputs": {
                 "test": {
                     "type": "duckdb",
-                    "path": "test.duckdb",
+                    "path": ":memory:",
                 }
             },
             "target": "test",


### PR DESCRIPTION
DuckDB 0.7.0 ships with support for multiple databases on the same connection, and I'd like to add support for this in two ways:

1) The `profile` should support the `ATTACH` options for an arbitrary number of database files (either DuckDB or SQLite) at the start of a dbt run,
2) It should be possible to do writes to _any_ of the attached databases (that aren't in read-only mode), which means that our DDL and DML statements need to be fully-specified as `database.schema.relation` by default. This will only work correctly for DuckDB 0.7.0 though, so for now I'm controlling this setting via a method on the `adapter` that checks the version of DuckDB we are running and does the "right" thing.

As the 0.7.x releases of DuckDB mature I will look at making including the database in the DML/DDL the default and I'll get rid of this hack I'm doing while we're in an in-between state.
