### PR TITLE
feat: inherit defaults for file formats from location

### DIFF
--- a/dbt/include/duckdb/macros/materializations/external.sql
+++ b/dbt/include/duckdb/macros/materializations/external.sql
@@ -6,6 +6,9 @@
   {%- set glue_register = config.get('glue_register', default=false) -%}
   {%- set glue_database = render(config.get('glue_database', default='default')) -%}
 
+  -- inherit format from defined location when it is not passed
+  {% set format = location.split('.') | last if not config.get('format')%}
+
   -- set language - python or sql
   {%- set language = model['language'] -%}
 

--- a/tests/functional/adapter/test_external.py
+++ b/tests/functional/adapter/test_external.py
@@ -29,10 +29,15 @@ config_materialized_csv_delim = """
   {{ config(materialized="external", format="csv", location="test_delim.csv", delimiter="|") }}
 """
 
+config_materialized_csv_no_format = """
+  {{ config(materialized="external", location="test.csv") }}
+"""
+
 default_external_sql = config_materialized_default + model_base
 parquet_table_location_sql = config_materialized_parquet_with_location + model_base
 csv_table_sql = config_materialized_csv + model_base
 csv_table_delim_sql = config_materialized_csv_delim + model_base
+csv_table_no_format_sql = config_materialized_csv_no_format + model_base
 
 
 class BaseExternalMaterializations:
@@ -44,6 +49,7 @@ class BaseExternalMaterializations:
             "table_parquet.sql": parquet_table_location_sql,
             "table_csv.sql": csv_table_sql,
             "table_csv_delim.sql": csv_table_delim_sql,
+            "table_csv_no_format.sql": csv_table_no_format_sql,
             "schema.yml": schema_base_yml,
         }
 
@@ -69,7 +75,7 @@ class BaseExternalMaterializations:
         # run command
         results = run_dbt()
         # run result length
-        assert len(results) == 5
+        assert len(results) == 6
 
         # names exist in result nodes
         check_result_nodes_by_name(
@@ -80,6 +86,7 @@ class BaseExternalMaterializations:
                 "table_parquet",
                 "table_csv",
                 "table_csv_delim",
+                "table_csv_no_format",
             ],
         )
 
@@ -91,6 +98,7 @@ class BaseExternalMaterializations:
             "table_model": "table",
             "table_csv": "view",
             "table_csv_delim": "view",
+            "table_csv_no_format": "view",
         }
         check_relation_types(project.adapter, expected)
 
@@ -109,12 +117,13 @@ class BaseExternalMaterializations:
                 "table_model",
                 "table_csv",
                 "table_csv_delim",
+                "table_csv_no_format"
             ],
         )
 
         # check relations in catalog
         catalog = run_dbt(["docs", "generate"])
-        assert len(catalog.nodes) == 6
+        assert len(catalog.nodes) == 7
         assert len(catalog.sources) == 1
 
 


### PR DESCRIPTION
solves: https://github.com/jwills/dbt-duckdb/issues/104

Also, I think there is some better handling around location & format (I think one should be required but not both). Happy to submit some changes in a PR.

Originally I was planning on adding json support to the external materialization @jwills, but based on the code I think that's already supported? Happy to add changes to the readme if this is the case.