### PR TITLE
Fix register_upstream_external_models macro

### DIFF
--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -35,5 +35,6 @@
     {% endif %}
   {% endfor %}
 {% endfor %}
+{% do adapter.commit() %}
 {% endif %}
 {%- endmacro -%}

--- a/tests/functional/adapter/test_external_rematerialize.py
+++ b/tests/functional/adapter/test_external_rematerialize.py
@@ -30,6 +30,7 @@ class TestRematerializeDownstreamExternalModel:
         return {
             "type": "duckdb",
             "path": ":memory:",
+            "threads": 3,
         }
 
     @pytest.fixture(scope="class")
@@ -53,4 +54,4 @@ class TestRematerializeDownstreamExternalModel:
 
         # Force close the :memory: connection
         DuckDBConnectionManager.close_all_connections()
-        run_dbt(["run", "--select", "downstream_model,other_downstream_model"])
+        run_dbt(["run", "--select", "downstream_model other_downstream_model"])


### PR DESCRIPTION
Fixes https://github.com/jwills/dbt-duckdb/issues/108
- fix register_upstream_external_models macro to commit the newly created views.
- fix test to use dbt selection syntax that runs the union of both models, not their empty intersection. 