### PR TITLE
fix: clear connections before tests

### DIFF
--- a/tests/functional/fsspec/test_filesystems.py
+++ b/tests/functional/fsspec/test_filesystems.py
@@ -1,5 +1,6 @@
 import pytest
 from dbt.tests.util import run_dbt
+from dbt.adapters.duckdb.connections import DuckDBConnectionManager
 
 models_file_model_sql = """
 {{ config(materialized='table') }}
@@ -34,5 +35,6 @@ class TestFilesystems:
         }
 
     def test_filesystems(self, project):
+        DuckDBConnectionManager.close_all_connections()
         results = run_dbt()
         assert len(results) == 1

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import dbt.flags as flags
 from dbt.adapters.duckdb import DuckDBAdapter
+from dbt.adapters.duckdb.connections import DuckDBConnectionManager
 from tests.unit.utils import config_from_parts_or_dicts, mock_connection
 
 
@@ -44,6 +45,7 @@ class TestDuckDBAdapter(unittest.TestCase):
 
     @mock.patch("dbt.adapters.duckdb.connections.duckdb")
     def test_acquire_connection(self, connector):
+        DuckDBConnectionManager.close_all_connections()
         connection = self.adapter.acquire_connection("dummy")
 
         connector.connect.assert_not_called()


### PR DESCRIPTION
There are two tests which expect no connections to be opened. This is the case when run by themselves, but running other tests in the same pytest session can affect the class-level variable `DuckDBConnectionManager.CONN`

Until this class-level variable can be fixed, we reset the connections before these affected tests.

@jwills would you prefer that before *every* test runs the connections are reset? Can instead have a pytest fixture with `autouse=True` if you would prefer a less ad-hoc, if more invasive, approach.