### PR TITLE
fix: handle multithreaded writes of pyarrow models

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -50,36 +50,14 @@
 {{ compiled_code }}
 
 def materialize(df, con):
-    # For the DuckDBPyRelation checks
-    import duckdb
-
-    # make sure pandas exists before using it
-    try:
-        import pandas
-        pandas_available = True
-    except ImportError:
-        pandas_available = False
-
-    # make sure pyarrow exists before using it
     try:
         import pyarrow
-        pyarrow_available = True
     except ImportError:
-        pyarrow_available = False
-
-    if isinstance(df, duckdb.DuckDBPyRelation):
-        if pyarrow_available:
-            df = df.arrow()
-        elif pandas_available:
-            df = df.df()
-        else:
-            raise Exception("No pandas or pyarrow available to materialize DuckDBPyRelation")
-    elif not (
-      (pandas_available and isinstance(df, pandas.DataFrame))
-      or (pyarrow_available and isinstance(df, pyarrow.Table))
-    ):
-        raise Exception( str(type(df)) + " is not a supported type for dbt Python materialization")
-
+        pass
+    finally:
+        if isinstance(df, pyarrow.Table):
+            # https://github.com/duckdb/duckdb/issues/6584
+            import pyarrow.dataset
     con.execute('create table {{ relation.include(database=adapter.use_database()) }} as select * from df')
 {% endmacro %}
 


### PR DESCRIPTION
Multi-threaded writing of python models returning pyarrow.Table fails due to an upstream bug: https://github.com/duckdb/duckdb/issues/6584

- add in the workaround to import `pyarrow.dataset` on materialization.
- remove the round-trip conversion of python models returning a duckdbPyRelation to a `pyarrow.Table/pandas.DataFrame` and back. This will also enable `polars` or any other dataframe-like models to work within dbt-duckdb.

@jwills @tomsej is there some subtle detail I'm missing about why this round-trip logic was here in the first place? Some old bug with duckdb not finding bound DuckdbPyRelation variables?

Related: https://github.com/duckdb/duckdb/issues/5038 was fixed as of duckdb 0.6.0 so might want to go this route instead of relying on duckdb's magic variable binding.