### PR TITLE
Refactor the code in the `connections` module into the `credentials` and `environments` modules

### DIFF
--- a/dbt/adapters/duckdb/__init__.py
+++ b/dbt/adapters/duckdb/__init__.py
@@ -1,6 +1,6 @@
 from dbt.adapters.base import AdapterPlugin
 from dbt.adapters.duckdb.connections import DuckDBConnectionManager  # noqa
-from dbt.adapters.duckdb.connections import DuckDBCredentials
+from dbt.adapters.duckdb.credentials import DuckDBCredentials
 from dbt.adapters.duckdb.impl import DuckDBAdapter
 from dbt.include import duckdb
 

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -1,20 +1,8 @@
 import atexit
-import os
 import threading
-import time
 from contextlib import contextmanager
-from dataclasses import dataclass
-from functools import lru_cache
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
-
-import duckdb
 
 import dbt.exceptions
-from dbt.adapters.base import Credentials
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import AdapterRequiredConfig
 from dbt.contracts.connection import AdapterResponse
@@ -22,175 +10,13 @@ from dbt.contracts.connection import Connection
 from dbt.contracts.connection import ConnectionState
 from dbt.logger import GLOBAL_LOGGER as logger
 
-
-@dataclass
-class Attachment:
-    # The path to the database to be attached; may be a URL
-    path: str
-
-    # The type of the attached database (defaults to duckdb, but may be supported by an extension)
-    type: Optional[str] = None
-
-    # An optional alias for the attached database
-    alias: Optional[str] = None
-
-    # Whether the attached database is read-only or read/write
-    read_only: bool = False
-
-    def to_sql(self) -> str:
-        base = f"ATTACH '{self.path}'"
-        if self.alias:
-            base += f" AS {self.alias}"
-        options = []
-        if self.type:
-            options.append(f"TYPE {self.type}")
-        if self.read_only:
-            options.append("READ_ONLY")
-        if options:
-            joined = ", ".join(options)
-            base += f" ({joined})"
-        return base
-
-
-@dataclass
-class DuckDBCredentials(Credentials):
-    database: str = "main"
-    schema: str = "main"
-    path: str = ":memory:"
-
-    # any extensions we want to install and load (httpfs, parquet, etc.)
-    extensions: Optional[Tuple[str, ...]] = None
-
-    # any additional pragmas we want to configure on our DuckDB connections;
-    # a list of the built-in pragmas can be found here:
-    # https://duckdb.org/docs/sql/configuration
-    # (and extensions may add their own pragmas as well)
-    settings: Optional[Dict[str, Any]] = None
-
-    # the root path to use for any external materializations that are specified
-    # in this dbt project; defaults to "." (the current working directory)
-    external_root: str = "."
-
-    # identify whether to use the default credential provider chain for AWS/GCloud
-    # instead of statically defined environment variables
-    use_credential_provider: Optional[str] = None
-
-    # A list of additional databases that should be attached to the running
-    # DuckDB instance to make them available for use in models; see the
-    # schema for the Attachment dataclass above for what fields it can contain
-    attach: Optional[List[Dict[str, Any]]] = None
-
-    # A list of filesystems to attach to the DuckDB database via the fsspec
-    # interface; see https://duckdb.org/docs/guides/python/filesystems.html
-    #
-    # Each dictionary entry must have a "fs" entry to indicate which
-    # fsspec implementation should be loaded, and then an arbitrary additional
-    # number of key-value pairs that will be passed as arguments to the fsspec
-    # registry method.
-    filesystems: Optional[List[Dict[str, Any]]] = None
-
-    @classmethod
-    def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
-        data = super().__pre_deserialize__(data)
-        path = data["path"]
-        if duckdb.__version__ >= "0.7.0":
-            if path == ":memory:":
-                data["database"] = "memory"
-            else:
-                data["database"] = os.path.splitext(os.path.basename(path))[0]
-        return data
-
-    @property
-    def type(self):
-        return "duckdb"
-
-    def _connection_keys(self):
-        return ("database", "schema", "path")
-
-    def load_settings(self) -> Dict[str, str]:
-        settings = self.settings or {}
-        if self.use_credential_provider:
-            if self.use_credential_provider == "aws":
-                settings.update(_load_aws_credentials(ttl=_get_ttl_hash()))
-            else:
-                raise ValueError(
-                    "Unsupported value for use_credential_provider: "
-                    + self.use_credential_provider
-                )
-        return settings
-
-
-def _get_ttl_hash(seconds=300):
-    """Return the same value withing `seconds` time period"""
-    return round(time.time() / seconds)
-
-
-@lru_cache()
-def _load_aws_credentials(ttl=None) -> Dict[str, Any]:
-    del ttl  # make mypy happy
-    import boto3.session
-
-    session = boto3.session.Session()
-
-    # use STS to verify that the credentials are valid; we will
-    # raise a helpful error here if they are not
-    sts = session.client("sts")
-    sts.get_caller_identity()
-
-    # now extract/return them
-    aws_creds = session.get_credentials().get_frozen_credentials()
-    return {
-        "s3_access_key_id": aws_creds.access_key,
-        "s3_secret_access_key": aws_creds.secret_key,
-        "s3_session_token": aws_creds.token,
-        "s3_region": session.region_name,
-    }
-
-
-class DuckDBCursorWrapper:
-    def __init__(self, cursor):
-        self._cursor = cursor
-
-    # forward along all non-execute() methods/attribute look ups
-    def __getattr__(self, name):
-        return getattr(self._cursor, name)
-
-    def execute(self, sql, bindings=None):
-        try:
-            if bindings is None:
-                return self._cursor.execute(sql)
-            else:
-                return self._cursor.execute(sql, bindings)
-        except RuntimeError as e:
-            raise dbt.exceptions.DbtRuntimeError(str(e))
-
-
-class DuckDBConnectionWrapper:
-    def __init__(self, conn, credentials):
-        self._conn = conn
-
-        # Extensions/settings need to be configured per cursor
-        cursor = conn.cursor()
-        for ext in credentials.extensions or []:
-            cursor.execute(f"LOAD '{ext}'")
-        for key, value in credentials.load_settings().items():
-            # Okay to set these as strings because DuckDB will cast them
-            # to the correct type
-            cursor.execute(f"SET {key} = '{value}'")
-        self._cursor = DuckDBCursorWrapper(cursor)
-
-    def __getattr__(self, name):
-        return getattr(self._conn, name)
-
-    def cursor(self):
-        return self._cursor
+from . import environments
 
 
 class DuckDBConnectionManager(SQLConnectionManager):
     TYPE = "duckdb"
     LOCK = threading.RLock()
-    CONN = None
-    CONN_COUNT = 0
+    ENV = None
 
     def __init__(self, profile: AdapterRequiredConfig):
         super().__init__(profile)
@@ -204,43 +30,17 @@ class DuckDBConnectionManager(SQLConnectionManager):
         credentials = cls.get_credentials(connection.credentials)
         with cls.LOCK:
             try:
-                if not cls.CONN:
-                    cls.CONN = duckdb.connect(credentials.path, read_only=False)
-
-                    # install any extensions on the connection
-                    if credentials.extensions is not None:
-                        for extension in credentials.extensions:
-                            cls.CONN.execute(f"INSTALL '{extension}'")
-
-                    # Attach any fsspec filesystems on the database
-                    if credentials.filesystems:
-                        import fsspec
-
-                        for spec in credentials.filesystems:
-                            curr = spec.copy()
-                            fsimpl = curr.pop("fs")
-                            fs = fsspec.filesystem(fsimpl, **curr)
-                            cls.CONN.register_filesystem(fs)
-
-                    # attach any databases that we will be using
-                    if credentials.attach:
-                        for entry in credentials.attach:
-                            attachment = Attachment(**entry)
-                            cls.CONN.execute(attachment.to_sql())
-
-                connection.handle = DuckDBConnectionWrapper(cls.CONN.cursor(), credentials)
+                if not cls.ENV:
+                    cls.ENV = environments.create(credentials)
+                connection.handle = cls.ENV.handle()
                 connection.state = ConnectionState.OPEN
-                cls.CONN_COUNT += 1
 
             except RuntimeError as e:
-                logger.debug(
-                    "Got an error when attempting to open a duckdb " "database: '{}'".format(e)
-                )
-
+                logger.debug("Got an error when attempting to connect to DuckDB: '{}'".format(e))
                 connection.handle = None
                 connection.state = ConnectionState.FAIL
-
                 raise dbt.exceptions.FailedToConnectError(str(e))
+
             return connection
 
     @classmethod
@@ -250,15 +50,6 @@ class DuckDBConnectionManager(SQLConnectionManager):
             return connection
 
         connection = super(SQLConnectionManager, cls).close(connection)
-
-        if connection.state == ConnectionState.CLOSED:
-            credentials = cls.get_credentials(connection.credentials)
-            with cls.LOCK:
-                cls.CONN_COUNT -= 1
-                if cls.CONN_COUNT == 0 and cls.CONN and not credentials.path == ":memory:":
-                    cls.CONN.close()
-                    cls.CONN = None
-
         return connection
 
     def cancel(self, connection):
@@ -290,9 +81,8 @@ class DuckDBConnectionManager(SQLConnectionManager):
     @classmethod
     def close_all_connections(cls):
         with cls.LOCK:
-            if cls.CONN is not None:
-                cls.CONN.close()
-                cls.CONN = None
+            if cls.ENV is not None:
+                cls.ENV = None
 
 
 atexit.register(DuckDBConnectionManager.close_all_connections)

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -3,14 +3,13 @@ import threading
 from contextlib import contextmanager
 
 import dbt.exceptions
+from . import environments
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import AdapterRequiredConfig
 from dbt.contracts.connection import AdapterResponse
 from dbt.contracts.connection import Connection
 from dbt.contracts.connection import ConnectionState
 from dbt.logger import GLOBAL_LOGGER as logger
-
-from . import environments
 
 
 class DuckDBConnectionManager(SQLConnectionManager):

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -9,6 +9,7 @@ from typing import Optional
 from typing import Tuple
 
 import duckdb
+
 from dbt.adapters.base import Credentials
 
 

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -1,0 +1,136 @@
+import os
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import duckdb
+from dbt.adapters.base import Credentials
+
+
+@dataclass
+class Attachment:
+    # The path to the database to be attached; may be a URL
+    path: str
+
+    # The type of the attached database (defaults to duckdb, but may be supported by an extension)
+    type: Optional[str] = None
+
+    # An optional alias for the attached database
+    alias: Optional[str] = None
+
+    # Whether the attached database is read-only or read/write
+    read_only: bool = False
+
+    def to_sql(self) -> str:
+        base = f"ATTACH '{self.path}'"
+        if self.alias:
+            base += f" AS {self.alias}"
+        options = []
+        if self.type:
+            options.append(f"TYPE {self.type}")
+        if self.read_only:
+            options.append("READ_ONLY")
+        if options:
+            joined = ", ".join(options)
+            base += f" ({joined})"
+        return base
+
+
+@dataclass
+class DuckDBCredentials(Credentials):
+    database: str = "main"
+    schema: str = "main"
+    path: str = ":memory:"
+
+    # any extensions we want to install and load (httpfs, parquet, etc.)
+    extensions: Optional[Tuple[str, ...]] = None
+
+    # any additional pragmas we want to configure on our DuckDB connections;
+    # a list of the built-in pragmas can be found here:
+    # https://duckdb.org/docs/sql/configuration
+    # (and extensions may add their own pragmas as well)
+    settings: Optional[Dict[str, Any]] = None
+
+    # the root path to use for any external materializations that are specified
+    # in this dbt project; defaults to "." (the current working directory)
+    external_root: str = "."
+
+    # identify whether to use the default credential provider chain for AWS/GCloud
+    # instead of statically defined environment variables
+    use_credential_provider: Optional[str] = None
+
+    # A list of additional databases that should be attached to the running
+    # DuckDB instance to make them available for use in models; see the
+    # schema for the Attachment dataclass above for what fields it can contain
+    attach: Optional[List[Dict[str, Any]]] = None
+
+    # A list of filesystems to attach to the DuckDB database via the fsspec
+    # interface; see https://duckdb.org/docs/guides/python/filesystems.html
+    #
+    # Each dictionary entry must have a "fs" entry to indicate which
+    # fsspec implementation should be loaded, and then an arbitrary additional
+    # number of key-value pairs that will be passed as arguments to the fsspec
+    # registry method.
+    filesystems: Optional[List[Dict[str, Any]]] = None
+
+    @classmethod
+    def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
+        data = super().__pre_deserialize__(data)
+        path = data["path"]
+        if duckdb.__version__ >= "0.7.0":
+            if path == ":memory:":
+                data["database"] = "memory"
+            else:
+                data["database"] = os.path.splitext(os.path.basename(path))[0]
+        return data
+
+    @property
+    def type(self):
+        return "duckdb"
+
+    def _connection_keys(self):
+        return ("database", "schema", "path")
+
+    def load_settings(self) -> Dict[str, str]:
+        settings = self.settings or {}
+        if self.use_credential_provider:
+            if self.use_credential_provider == "aws":
+                settings.update(_load_aws_credentials(ttl=_get_ttl_hash()))
+            else:
+                raise ValueError(
+                    "Unsupported value for use_credential_provider: "
+                    + self.use_credential_provider
+                )
+        return settings
+
+
+def _get_ttl_hash(seconds=300):
+    """Return the same value withing `seconds` time period"""
+    return round(time.time() / seconds)
+
+
+@lru_cache()
+def _load_aws_credentials(ttl=None) -> Dict[str, Any]:
+    del ttl  # make mypy happy
+    import boto3.session
+
+    session = boto3.session.Session()
+
+    # use STS to verify that the credentials are valid; we will
+    # raise a helpful error here if they are not
+    sts = session.client("sts")
+    sts.get_caller_identity()
+
+    # now extract/return them
+    aws_creds = session.get_credentials().get_frozen_credentials()
+    return {
+        "s3_access_key_id": aws_creds.access_key,
+        "s3_secret_access_key": aws_creds.secret_key,
+        "s3_session_token": aws_creds.token,
+        "s3_region": session.region_name,
+    }

--- a/dbt/adapters/duckdb/environments.py
+++ b/dbt/adapters/duckdb/environments.py
@@ -1,0 +1,102 @@
+import dbt.exceptions
+import duckdb
+
+from .credentials import Attachment, DuckDBCredentials
+
+
+class DuckDBCursorWrapper:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    # forward along all non-execute() methods/attribute look ups
+    def __getattr__(self, name):
+        return getattr(self._cursor, name)
+
+    def execute(self, sql, bindings=None):
+        try:
+            if bindings is None:
+                return self._cursor.execute(sql)
+            else:
+                return self._cursor.execute(sql, bindings)
+        except RuntimeError as e:
+            raise dbt.exceptions.DbtRuntimeError(str(e))
+
+
+class DuckDBConnectionWrapper:
+    def __init__(self, env):
+        self._env = env
+        self._cursor = DuckDBCursorWrapper(env.cursor())
+
+    def close(self):
+        self._env.close(self._cursor)
+
+    def cursor(self):
+        return self._cursor
+
+
+class Environment:
+    def handle(self):
+        raise NotImplementedError
+
+    def cursor(self):
+        raise NotImplementedError
+
+    def close(self):
+        raise NotImplementedError
+
+
+class LocalEnvironment(Environment):
+    def __init__(self, credentials: DuckDBCredentials):
+        self.creds = credentials
+        self.handles = 0
+        self.conn = duckdb.connect(credentials.path, read_only=False)
+        # install any extensions on the connection
+        if credentials.extensions is not None:
+            for extension in credentials.extensions:
+                self.conn.execute(f"INSTALL '{extension}'")
+
+        # Attach any fsspec filesystems on the database
+        if credentials.filesystems:
+            import fsspec
+
+            for spec in credentials.filesystems:
+                curr = spec.copy()
+                fsimpl = curr.pop("fs")
+                fs = fsspec.filesystem(fsimpl, **curr)
+                self.conn.register_filesystem(fs)
+
+        # attach any databases that we will be using
+        if credentials.attach:
+            for entry in credentials.attach:
+                attachment = Attachment(**entry)
+                self.conn.execute(attachment.to_sql())
+
+    def handle(self):
+        self.handles += 1
+        return DuckDBConnectionWrapper(self)
+
+    def cursor(self):
+        # Extensions/settings need to be configured per cursor
+        cursor = self.conn.cursor()
+        for ext in self.creds.extensions or []:
+            cursor.execute(f"LOAD '{ext}'")
+        for key, value in self.creds.load_settings().items():
+            # Okay to set these as strings because DuckDB will cast them
+            # to the correct type
+            cursor.execute(f"SET {key} = '{value}'")
+        return cursor
+
+    def close(self, cursor):
+        cursor.close()
+        self.handles -= 1
+        if self.conn and self.handles == 0 and self.creds.path != ":memory:":
+            self.conn.close()
+            self.conn = None
+
+    def __del__(self):
+        self.conn.close()
+        self.conn = None
+
+
+def create(creds: DuckDBCredentials) -> Environment:
+    return LocalEnvironment(creds)

--- a/dbt/adapters/duckdb/environments.py
+++ b/dbt/adapters/duckdb/environments.py
@@ -1,7 +1,8 @@
-import dbt.exceptions
 import duckdb
 
-from .credentials import Attachment, DuckDBCredentials
+import dbt.exceptions
+from .credentials import Attachment
+from .credentials import DuckDBCredentials
 
 
 class DuckDBCursorWrapper:

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from botocore.credentials import Credentials
 
-from dbt.adapters.duckdb.connections import Attachment, DuckDBCredentials
+from dbt.adapters.duckdb.credentials import Attachment, DuckDBCredentials
 
 
 def test_load_basic_settings():

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -43,7 +43,7 @@ class TestDuckDBAdapter(unittest.TestCase):
             self._adapter = DuckDBAdapter(self.config)
         return self._adapter
 
-    @mock.patch("dbt.adapters.duckdb.connections.duckdb")
+    @mock.patch("dbt.adapters.duckdb.environments.duckdb")
     def test_acquire_connection(self, connector):
         DuckDBConnectionManager.close_all_connections()
         connection = self.adapter.acquire_connection("dummy")


### PR DESCRIPTION
I'm starting to experiment with the idea of connecting to a DuckDB database running in a remote process (e.g., using https://github.com/jwills/buenavista ) and realized that I would need a mechanism to handle certain bits of functionality that are currently done locally (e.g., loading a `fsspec` filesystem or executing a Python model) by sending code/instructions to the remote process.

To lay the foundation for this work, I'm refactoring the `connections` module (which has become a bit overloaded with code tbh) into a `credentials` module (for, well, the credentials) and an `environments` module that will allow me to define different kinds of execution environments for a particular dbt-duckdb run.