### PR TITLE
Upstream model registration redux

### DIFF
--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -16,8 +16,8 @@
           schema=upstream['schema'],
           identifier=upstream['alias']
         ) -%}
-        {%- set location = upstream.config.get('location', external_location(upstream, upstream.config)) -%}
-        {%- set rendered_options = render_write_options(config) -%}
+        {%- set location = upstream.config.get('location', external_location(upstream_rel, upstream.config)) -%}
+        {%- set rendered_options = render_write_options(upstream.config) -%}
         {%- set upstream_location = adapter.external_read_location(location, rendered_options) -%}
         {% if upstream_rel.schema not in upstream_schemas %}
           {% call statement('main', language='sql') -%}

--- a/tests/functional/adapter/test_rematerialize.py
+++ b/tests/functional/adapter/test_rematerialize.py
@@ -1,5 +1,5 @@
 import pytest
-from dbt.tests.util import run_dbt
+from dbt.tests.util import run_dbt, relation_from_name
 from dbt.adapters.duckdb import DuckDBConnectionManager
 
 upstream_model_sql = """
@@ -68,6 +68,12 @@ class TestRematerializeDownstreamExternalModel:
             [
                 "run",
                 "--select",
-                "downstream_model,other_downstream_model,downstream_of_partition_model",
+                "downstream_model other_downstream_model downstream_of_partition_model",
             ]
         )
+
+        # really makes sure we have created the downstream model
+        relation = relation_from_name(project.adapter, "downstream_of_partition_model")
+        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+        assert result[0] == 5
+


### PR DESCRIPTION
A couple more fixes for https://github.com/jwills/dbt-duckdb/pull/125

* Fix comma vs spaces causing empty test
* Really ensure the models are getting created in this test
* Use the upstream config to generate the upstream options.