### PR TITLE
Run every functional test in multithreaded mode by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,6 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 def dbt_profile_target():
     return {
         "type": "duckdb",
-        "threads": 1,
+        "threads": 4,
         "path": ":memory:",
     }

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -124,14 +124,6 @@ class TestMultiThreadedImports:
     """
 
     @pytest.fixture(scope="class")
-    def dbt_profile_target(self):
-        return {
-            "type": "duckdb",
-            "path": ":memory:",
-            "threads": 2,
-        }
-
-    @pytest.fixture(scope="class")
     def models(self):
         return {
             "model_table1.py": python_pyarrow_table_model,

--- a/tests/functional/adapter/test_rematerialize.py
+++ b/tests/functional/adapter/test_rematerialize.py
@@ -34,14 +34,6 @@ class TestRematerializeDownstreamExternalModel:
     """
 
     @pytest.fixture(scope="class")
-    def dbt_profile_target(self):
-        return {
-            "type": "duckdb",
-            "path": ":memory:",
-            "threads": 3,
-        }
-
-    @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
             "name": "base",


### PR DESCRIPTION
We have some functional tests that need to override the default profile target b/c they run in multithreaded mode and I'm thinking it's better to just always test everything in multithreaded mode.