### PR TITLE
Inject any key-value pairs from the `meta` dictionary into the f-string context for external locations

### DIFF
--- a/dbt/adapters/duckdb/relation.py
+++ b/dbt/adapters/duckdb/relation.py
@@ -31,9 +31,14 @@ class DuckDBRelation(BaseRelation):
             # can be injected into the string; this helps reduce boilerplate when all
             # of the tables in the source have a similar location based on their name
             # and/or identifier.
-            ext_location = ext_location.format(
-                schema=source.schema, name=source.name, identifier=source.identifier
-            )
+            format_args = {
+                "schema": source.schema,
+                "name": source.name,
+                "identifier": source.identifier,
+            }
+            if source.meta:
+                format_args.update(source.meta)
+            ext_location = ext_location.format(**format_args)
             # If it's a function call or already has single quotes, don't add them
             if "(" not in ext_location and not ext_location.startswith("'"):
                 ext_location = f"'{ext_location}'"

--- a/tests/functional/adapter/test_sources.py
+++ b/tests/functional/adapter/test_sources.py
@@ -8,10 +8,12 @@ sources_schema_yml = """version: 2
 sources:
   - name: external_source
     meta:
-      external_location: "/tmp/{name}.csv"
+      external_location: "/tmp/{name}_{extra}.csv"
     tables:
       - name: seeds_source
         description: "A source table"
+        meta:
+          extra: 'something'
         columns:
           - name: id
             description: "An id"
@@ -58,10 +60,10 @@ class TestExternalSources:
 
     @pytest.fixture(scope="class")
     def seeds_source_file(self):
-        with open("/tmp/seeds_source.csv", "w") as f:
+        with open("/tmp/seeds_source_something.csv", "w") as f:
             f.write("id,a,b\n1,2,3\n4,5,6\n7,8,9")
         yield
-        os.unlink("/tmp/seeds_source.csv")
+        os.unlink("/tmp/seeds_source_something.csv")
 
     @pytest.fixture(scope="class")
     def ost_file(self):


### PR DESCRIPTION
Fixes #127 