### PR TITLE
Enable testing with file DB and fix bug in connection handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/
@@ -74,6 +75,4 @@ target/
 
 .python-version
 
-# Vim
-*.sw*
 .DS_Store

--- a/dbt/adapters/duckdb/environments.py
+++ b/dbt/adapters/duckdb/environments.py
@@ -9,7 +9,7 @@ class DuckDBCursorWrapper:
     def __init__(self, cursor):
         self._cursor = cursor
 
-    # forward along all non-execute() methods/attribute look ups
+    # forward along all non-execute() methods/attribute look-ups
     def __getattr__(self, name):
         return getattr(self._cursor, name)
 
@@ -90,9 +90,6 @@ class LocalEnvironment(Environment):
     def close(self, cursor):
         cursor.close()
         self.handles -= 1
-        if self.conn and self.handles == 0 and self.creds.path != ":memory:":
-            self.conn.close()
-            self.conn = None
 
     def __del__(self):
         self.conn.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def dbt_profile_target(request, tmp_path_factory):
 
     if profile_type == "memory":
         path = ":memory:"
-    elif profile_type == "database":
+    elif profile_type == "file":
         path = str(tmp_path_factory.getbasetemp() / "tmp.db")
     else:
         raise ValueError(f"Invalid profile type '{profile_type}'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,29 @@
 import pytest
-import os
 
 # Import the standard functional fixtures as a plugin
 # Note: fixtures with session scope need to be local
 pytest_plugins = ["dbt.tests.fixtures.project"]
 
+
+def pytest_addoption(parser):
+    parser.addoption("--profile", action="store", default="memory", type=str)
+
+
 # The profile dictionary, used to write out profiles.yml
 # dbt will supply a unique schema per test, so we do not specify 'schema' here
 @pytest.fixture(scope="class")
-def dbt_profile_target():
+def dbt_profile_target(request, tmp_path_factory):
+    profile_type = request.config.getoption("--profile")
+
+    if profile_type == "memory":
+        path = ":memory:"
+    elif profile_type == "database":
+        path = str(tmp_path_factory.getbasetemp() / "tmp.db")
+    else:
+        raise ValueError(f"Invalid profile type '{profile_type}'")
+
     return {
         "type": "duckdb",
         "threads": 4,
-        "path": ":memory:",
+        "path": path,
     }

--- a/tests/functional/adapter/test_attach.py
+++ b/tests/functional/adapter/test_attach.py
@@ -2,11 +2,11 @@ import os
 
 import duckdb
 import pytest
-import yaml
 
 from dbt.tests.util import run_dbt
 
-sources_schema_yml = """version: 2
+sources_schema_yml = """
+version: 2
 sources:
   - name: attached_source
     database: attach_test
@@ -22,7 +22,8 @@ sources:
               - not_null
 """
 
-models_source_model_sql = """select * from {{ source('attached_source', 'attached_table') }}
+models_source_model_sql = """
+    select * from {{ source('attached_source', 'attached_table') }}
 """
 
 models_target_model_sql = """
@@ -34,22 +35,23 @@ models_target_model_sql = """
 class TestAttachedDatabase:
     @pytest.fixture(scope="class")
     def attach_test_db(self):
-        db = duckdb.connect("/tmp/attach_test.duckdb")
+        path = "/tmp/attach_test.duckdb"
+        db = duckdb.connect(path)
         db.execute("CREATE SCHEMA analytics")
         db.execute("CREATE TABLE analytics.attached_table AS SELECT 1 as id")
         db.close()
-        yield
-        os.unlink("/tmp/attach_test.duckdb")
+        yield path
+        os.unlink(path)
 
     @pytest.fixture(scope="class")
-    def profiles_config_update(self, attach_test_db):
+    def profiles_config_update(self, dbt_profile_target, attach_test_db):
         return {
             "test": {
                 "outputs": {
                     "dev": {
                         "type": "duckdb",
-                        "path": ":memory:",
-                        "attach": [{"path": "/tmp/attach_test.duckdb"}],
+                        "path": dbt_profile_target["path"],
+                        "attach": [{"path": attach_test_db}],
                     }
                 },
                 "target": "dev",
@@ -64,7 +66,7 @@ class TestAttachedDatabase:
             "target_model.sql": models_target_model_sql,
         }
 
-    def test_attached_databases(self, project):
+    def test_attached_databases(self, project, attach_test_db):
         results = run_dbt()
         assert len(results) == 2
 
@@ -72,7 +74,7 @@ class TestAttachedDatabase:
         assert len(test_results) == 2
 
         # check that the model is created in the attached db
-        db = duckdb.connect("/tmp/attach_test.duckdb")
+        db = duckdb.connect(attach_test_db)
         ret = db.execute(f"SELECT * FROM target_model").fetchall()
         assert ret[0][0] == 1
 

--- a/tests/functional/adapter/test_ephemeral.py
+++ b/tests/functional/adapter/test_ephemeral.py
@@ -18,6 +18,8 @@ from dbt.tests.util import check_relations_equal, run_dbt
 
 class TestEphemeralMulti(BaseEphemeralMulti):
     def test_ephemeral_multi(self, project):
+        db = project.database
+
         run_dbt(["seed"])
         results = run_dbt(["run"])
         assert len(results) == 3
@@ -31,7 +33,7 @@ class TestEphemeralMulti(BaseEphemeralMulti):
 
         sql_file = re.sub(r"\d+", "", sql_file)
         expected_sql = (
-            'create view "memory"."test_test_ephemeral"."double_dependent__dbt_tmp" as ('
+            f'create view "{db}"."test_test_ephemeral"."double_dependent__dbt_tmp" as ('
             "with __dbt__cte__base as ("
             "select * from test_test_ephemeral.seed"
             "),  __dbt__cte__base_copy as ("
@@ -59,6 +61,8 @@ class TestEphemeralNested(BaseEphemeral):
         }
 
     def test_ephemeral_nested(self, project):
+        db = project.database
+
         results = run_dbt(["run"])
         assert len(results) == 2
         assert os.path.exists("./target/run/test/models/root_view.sql")
@@ -67,9 +71,9 @@ class TestEphemeralNested(BaseEphemeral):
 
         sql_file = re.sub(r"\d+", "", sql_file)
         expected_sql = (
-            'create view "memory"."test_test_ephemeral"."root_view__dbt_tmp" as ('
+            f'create view "{db}"."test_test_ephemeral"."root_view__dbt_tmp" as ('
             "with __dbt__cte__ephemeral_level_two as ("
-            'select * from "memory"."test_test_ephemeral"."source_table"'
+            f'select * from "{db}"."test_test_ephemeral"."source_table"'
             "),  __dbt__cte__ephemeral as ("
             "select * from __dbt__cte__ephemeral_level_two"
             ")select * from __dbt__cte__ephemeral"

--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -120,7 +120,7 @@ def model(dbt, con):
 class TestMultiThreadedImports:
     """
     This test ensures that multiple pyarrow models can run concurrently with threads > 1
-    and not suffer import issues
+    and not suffer import issues.
     """
 
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_rematerialize.py
+++ b/tests/functional/adapter/test_rematerialize.py
@@ -23,6 +23,7 @@ downstream_of_partition_model = """
 select a * 3 from {{ ref('upstream_partition_by_model') }}
 """
 
+
 # class must begin with 'Test'
 class TestRematerializeDownstreamExternalModel:
     """
@@ -68,4 +69,3 @@ class TestRematerializeDownstreamExternalModel:
         relation = relation_from_name(project.adapter, "downstream_of_partition_model")
         result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
         assert result[0] == 5
-

--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -114,7 +114,7 @@ class TestArrayConcat(BaseArrayConcat):
     pass
 
 
-class TestArrayConcat(BaseArrayConstruct):
+class TestArrayConstruct(BaseArrayConstruct):
     pass
 
 

--- a/tests/functional/fsspec/test_filesystems.py
+++ b/tests/functional/fsspec/test_filesystems.py
@@ -12,10 +12,10 @@ WHERE conf = 'West'
 
 class TestFilesystems:
     @pytest.fixture(scope="class")
-    def dbt_profile_target(self):
+    def dbt_profile_target(self, dbt_profile_target):
         return {
             "type": "duckdb",
-            "path": ":memory:",
+            "path": dbt_profile_target["path"],
             "filesystems": [{"fs": "github", "org": "jwills", "repo": "nba_monte_carlo"}],
         }
 


### PR DESCRIPTION
I noticed that the tests are only run against a `:memory:` database. This PR modifies the tests according to the [dbt documentation](https://docs.getdbt.com/guides/dbt-ecosystem/adapter-development/4-testing-a-new-adapter#running-with-multiple-profiles) to add testing profiles, allowing to switch between an in-memory and file-backed DuckDB backend (memory is kept as the default). The test can be run using a file by running `pytest --profile file`.

This change surfaces a bug in the Environment class, where the connection is prematurely closed due to the `handles` counting. I think that the `Environment.close(cursor)` behaviour is unwanted both for memory as file databases, which would make the handle counting unneeded as well. I simplified the implementation, fixing the issue, but I'm not sure if the handle counting served another purpose?

I suppose the `tox.ini` and github workflows should be updated as well to include the second testing path, but I'll let you review these changes first. Thanks!