### PR TITLE
only return non-empty creds to prevent code 400 when session token is empty

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -145,9 +145,12 @@ def _load_aws_credentials(ttl=None) -> Dict[str, Any]:
 
     # now extract/return them
     aws_creds = session.get_credentials().get_frozen_credentials()
-    return {
+
+    credentials = {
         "s3_access_key_id": aws_creds.access_key,
         "s3_secret_access_key": aws_creds.secret_key,
         "s3_session_token": aws_creds.token,
         "s3_region": session.region_name,
     }
+    # only return if value is filled
+    return {k: v for k, v in credentials.items() if v}


### PR DESCRIPTION
When testing out the credential provider functionality, external models pushed to S3 failed with the following error:

```
Invalid Error: IO Error: Unable to connect to URL "https://blabla.s3.amazonaws.com/some/file/name.parquet": 400 (Bad Request)
```
This was caused by boto3 not returning a session token in my setup and dbt-duckdb setting an empty string as variable in duckdb.
Now fixed by only passing the credentials with a value.