### PR TITLE
Set unique_field in credentials.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ target/
 .python-version
 
 .DS_Store
+.idea/

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -107,6 +107,10 @@ class DuckDBCredentials(Credentials):
         return data
 
     @property
+    def unique_field(self) -> str:
+        return self.database + self.schema + self.path
+
+    @property
     def type(self):
         return "duckdb"
 

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -108,7 +108,10 @@ class DuckDBCredentials(Credentials):
 
     @property
     def unique_field(self) -> str:
-        return self.database + self.schema + self.path
+        if self.remote:
+            return self.remote.host + str(self.remote.port)
+        else:
+            return self.path + self.external_root
 
     @property
     def type(self):


### PR DESCRIPTION
Required in dbt 1.5+ to avoid `NotImplementedError` raised here: https://github.com/dbt-labs/dbt-core/blob/3cee9d16fa39012e30a02c66770d6b6c7a445f6c/core/dbt/contracts/connection.py#L141