### PR TITLE
Enable additional iceberg config options + and add a Spark-style save_mode option for plugins

### DIFF
--- a/dbt/adapters/duckdb/plugins/iceberg.py
+++ b/dbt/adapters/duckdb/plugins/iceberg.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from pyiceberg import catalog
+import pyiceberg.catalog
 
 from . import Plugin
 from ..utils import SourceConfig
@@ -8,7 +8,10 @@ from ..utils import SourceConfig
 
 class IcebergPlugin(Plugin):
     def __init__(self, config: Dict):
-        self._catalog = catalog.load_catalog(config.get("catalog"))
+        if "catalog" not in config:
+            raise Exception("'catalog' is a required argument for the iceberg plugin!")
+        catalog = config.pop("catalog")
+        self._catalog = pyiceberg.catalog.load_catalog(catalog, **config)
 
     def load(self, source_config: SourceConfig):
         table_format = source_config.meta.get("iceberg_table", "{schema}.{identifier}")

--- a/tests/functional/plugins/test_plugins.py
+++ b/tests/functional/plugins/test_plugins.py
@@ -28,6 +28,7 @@ sources:
     schema: main
     meta:
       plugin: sql
+      save_mode: ignore
     tables:
       - name: tt1
         description: "My first SQLAlchemy table"


### PR DESCRIPTION
Fixing some config stuff that came up as I continued playing with Iceberg + adding in a `save_mode` option for the plugin sources so that we won't need to continually re-import a source if the relation has already been created if that doesn't make sense for the problem at hand.