### PR TITLE
Use info from the `source.config` and `source.table.config` entries for external data

### DIFF
--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -34,6 +34,8 @@ class SourceConfig:
     def create(cls, source: SourceDefinition) -> "SourceConfig":
         meta = source.source_meta.copy()
         meta.update(source.meta)
+        # Use the config properties as well if they are present
+        meta.update(source.config._extra)
         return SourceConfig(
             name=source.name,
             identifier=source.identifier,

--- a/tests/functional/adapter/test_sources.py
+++ b/tests/functional/adapter/test_sources.py
@@ -6,12 +6,12 @@ from dbt.tests.util import run_dbt
 sources_schema_yml = """version: 2
 sources:
   - name: external_source
-    meta:
+    config:
       external_location: "/tmp/{name}_{extra}.csv"
     tables:
       - name: seeds_source
         description: "A source table"
-        meta:
+        config:
           extra: 'something'
         columns:
           - name: id
@@ -21,7 +21,7 @@ sources:
               - not_null
       - name: seeds_ost
         identifier: "seeds_other_source_table"
-        meta:
+        config:
           external_location: "read_csv_auto('/tmp/{identifier}.csv')"
 """
 

--- a/tests/functional/plugins/test_plugins.py
+++ b/tests/functional/plugins/test_plugins.py
@@ -26,18 +26,18 @@ version: 2
 sources:
   - name: sql_source
     schema: main
-    meta:
+    config:
       plugin: sql
       save_mode: ignore
     tables:
       - name: tt1
         description: "My first SQLAlchemy table"
-        meta:
+        config:
           query: "SELECT * FROM {identifier} WHERE id=:id"
           params:
             id: 1
       - name: tt2
-        meta:
+        config:
           table: "test_table2"
 """
 


### PR DESCRIPTION
Historically I only used `meta` for these settings b/c I didn't realize I could actually access the extra config information from the `config` settings (i.e., beyond the `enabled` flag) 🤦 

This will be much better/clearer, though I'm obviously going to still support the `meta` settings for awhile for backwards compat