### PR TITLE
Support profiles that are simply 'type: duckdb' by correctly configuring the in-memory db setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,10 +50,10 @@ def dbt_profile_target(profile_type, bv_server_process, tmp_path_factory):
             "port": 5433,
             "user": "test",
         }
-    elif profile_type == "memory":
-        profile["path"] = ":memory:"
     elif profile_type == "file":
         profile["path"] = str(tmp_path_factory.getbasetemp() / "tmp.db")
+    elif profile_type == "memory":
+        pass  # use the default path-less profile
     else:
         raise ValueError(f"Invalid profile type '{profile_type}'")
 

--- a/tests/functional/adapter/test_attach.py
+++ b/tests/functional/adapter/test_attach.py
@@ -31,6 +31,7 @@ models_target_model_sql = """
     SELECT * FROM {{ ref('source_model') }}
 """
 
+
 @pytest.mark.skip_profile("buenavista")
 class TestAttachedDatabase:
     @pytest.fixture(scope="class")
@@ -45,14 +46,12 @@ class TestAttachedDatabase:
 
     @pytest.fixture(scope="class")
     def profiles_config_update(self, dbt_profile_target, attach_test_db):
-        if "path" not in dbt_profile_target:
-            return {}
         return {
             "test": {
                 "outputs": {
                     "dev": {
                         "type": "duckdb",
-                        "path": dbt_profile_target["path"],
+                        "path": dbt_profile_target.get("path", ":memory:"),
                         "attach": [{"path": attach_test_db}],
                     }
                 },

--- a/tests/functional/fsspec/test_filesystems.py
+++ b/tests/functional/fsspec/test_filesystems.py
@@ -9,6 +9,7 @@ from read_csv_auto('github://data/team_ratings.csv')
 WHERE conf = 'West'
 """
 
+
 @pytest.mark.skip_profile("buenavista")
 class TestFilesystems:
     @pytest.fixture(scope="class")
@@ -17,8 +18,10 @@ class TestFilesystems:
             return dbt_profile_target
         return {
             "type": "duckdb",
-            "path": dbt_profile_target["path"],
-            "filesystems": [{"fs": "github", "org": "jwills", "repo": "nba_monte_carlo"}],
+            "path": dbt_profile_target.get("path", ":memory:"),
+            "filesystems": [
+                {"fs": "github", "org": "jwills", "repo": "nba_monte_carlo"}
+            ],
         }
 
     @pytest.fixture(scope="class")

--- a/tests/functional/fsspec/test_filesystems.py
+++ b/tests/functional/fsspec/test_filesystems.py
@@ -14,8 +14,6 @@ WHERE conf = 'West'
 class TestFilesystems:
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):
-        if "path" not in dbt_profile_target:
-            return dbt_profile_target
         return {
             "type": "duckdb",
             "path": dbt_profile_target.get("path", ":memory:"),

--- a/tests/functional/plugins/test_plugins.py
+++ b/tests/functional/plugins/test_plugins.py
@@ -73,9 +73,6 @@ class TestPlugins:
 
     @pytest.fixture(scope="class")
     def profiles_config_update(self, dbt_profile_target, sqlite_test_db):
-        if "path" not in dbt_profile_target:
-            return {}
-
         config = {"connection_url": f"sqlite:///{sqlite_test_db}"}
         plugins = [
             {"name": "excel", "impl": "excel"},
@@ -87,7 +84,7 @@ class TestPlugins:
                 "outputs": {
                     "dev": {
                         "type": "duckdb",
-                        "path": dbt_profile_target["path"],
+                        "path": dbt_profile_target.get("path", ":memory:"),
                         "plugins": plugins,
                     }
                 },


### PR DESCRIPTION
Prior to DuckDB 0.7.0, dbt-duckdb could actually work out-of-the-box with no `path` argument at all, since the default value of the `path` argument was `:memory:` and the only database supported was the default of "main". 0.7.0 changed that s.t. if there is no `path` supplied, the value of the `database` setting needs to be "memory" for everything to work correctly; this PR updates the code so that the old behavior of running in-memory DBs when the path is unspecified will work correctly in the new regime.