### PR TITLE
Set a default value for the conn attribute in the case an exception is thrown during init

### DIFF
--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -36,6 +36,9 @@ class DuckDBConnectionWrapper:
 
 class LocalEnvironment(Environment):
     def __init__(self, credentials: credentials.DuckDBCredentials):
+        # Set the conn attribute to None so it always exists even if
+        # DB initialization fails
+        self.conn = None
         self.conn = self.initialize_db(credentials)
         self._plugins = self.initialize_plugins(credentials)
         self.creds = credentials


### PR DESCRIPTION
If the DuckDB file is inaccessible for some reason during dbt initialization, you get a spurious exception being thrown like `AttributeError: 'LocalEnvironment' object has no attribute 'conn'` because the `conn` attribute of the `LocalEnvironment` was never set due to the DB file being inaccessible.

Fixing that by always setting the `conn` attribute to `None` before we try to connect to the DB file so as not to distract the user with an unhelpful error.