### PR TITLE
pyarrow should not be required to run dbt-duckdb python models

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -76,10 +76,11 @@
 def materialize(df, con):
     try:
         import pyarrow
+        pyarrow_available = True
     except ImportError:
-        pass
+        pyarrow_available = False
     finally:
-        if isinstance(df, pyarrow.Table):
+        if pyarrow_available and isinstance(df, pyarrow.Table):
             # https://github.com/duckdb/duckdb/issues/6584
             import pyarrow.dataset
     con.execute('create table {{ relation.include(database=adapter.use_database()) }} as select * from df')


### PR DESCRIPTION
Fixes #155 b/c pyarrow should absolutely not be required for python models

verified this by uninstalling pyarrow and confirming that all of the python model tests passed except for the ones with explicit `pyarrow` dependencies; without this fix, all of the python model tests fail _unless_ `pyarrow` is installed.