### PR TITLE
Prepping the dbt-duckdb tests to pass under the next release of DuckDB

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import time
 
+import duckdb
 import pytest
 
 
@@ -42,6 +43,10 @@ def bv_server_process(profile_type):
 @pytest.fixture(scope="class")
 def dbt_profile_target(profile_type, bv_server_process, tmp_path_factory):
     profile = {"type": "duckdb", "threads": 4}
+
+    if duckdb.__version__ > "0.7.1":
+        # for backwards compatibility
+        profile["settings"] = {"integer_division": True}
 
     if profile_type == "buenavista":
         profile["database"] = "memory"

--- a/tests/functional/adapter/test_rematerialize.py
+++ b/tests/functional/adapter/test_rematerialize.py
@@ -21,7 +21,7 @@ select range * 5 from {{ ref('upstream_model') }}
 """
 
 downstream_of_partition_model = """
-select a * 3 from {{ ref('upstream_partition_by_model') }}
+select a from {{ ref('upstream_partition_by_model') }}
 """
 
 


### PR DESCRIPTION
Trying a new thing where I test out dbt-duckdb against the next release of DuckDB about a week-or-so before it comes out so I can get ahead of any bug fixes or updates I need in dbt-duckdb instead of having to scramble the day of the release to get stuff fixed.

Two things I needed to fix when I ran against `0.7.2-dev`:
1) Partition columns (in the Hive-partitioned sense) are now VARCHAR types
2) There is a [breaking change to the default division operator](https://github.com/duckdb/duckdb/pull/7082) such that it will now return floats by default instead of ints; this can be overridden by setting the `integer_division` setting to true, which I am doing here b/c some of the dbt tests fail without this setting in place.