### PR TITLE
Revamp the plugins setup to support configuring the DuckDBPyConnection instance directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,28 @@ support for persisting the tables that DuckDB creates to the [AWS Glue Catalog](
 
 ### Configuring Your Profile
 
-A minimal dbt-duckdb profile only needs two settings, `type` and `path`:
+A super-minimal dbt-duckdb profile only needs *one* setting:
 
 ````
 default:
   outputs:
    dev:
      type: duckdb
-     path: /tmp/dbt.duckdb
   target: dev
 ````
 
-The `path` field should normally be the path to a local DuckDB file on your filesystem, but it can also be set equal to `:memory:` if you
-would like to run an in-memory only version of dbt-duckdb. Keep in mind that if you are using the in-memory mode,
-any models that you want to keep from the dbt run will need to be persisted using one of the external materialization strategies described below.
+This will run your dbt-duckdb pipeline against an in-memory DuckDB database that will not be persisted after your run completes. This may
+not seem very useful at first, but it turns out to be a powerful tool for a) testing out data pipelines, either locally or in CI jobs and
+b) running data pipelines that operate purely on external CSV, Parquet, or JSON files. More details on how to work with external data files
+in dbt-duckdb are provided in the docs on [reading and writing external files](#reading-and-writing-external-files).
+
+To have your dbt pipeline persist relations in a DuckDB file, set the `path` field in your profile to the path
+of the DuckDB file that you would like to read and write on your local filesystem. (For in-memory pipelines, the `path`
+is automatically set to the special value `:memory:`).
 
 `dbt-duckdb` also supports common profile fields like `schema` and `threads`, but the `database` property is special: it's value is automatically set
 to the basename of the file in the `path` argument with the suffix removed. For example, if the `path` is `/tmp/a/dbfile.duckdb`, the `database`
-field will be set to `dbfile`. If you are running with the `path` equal to `:memory:`, then the name of the database will be `memory`.
+field will be set to `dbfile`. If you are running in in-memory mode, then the `database` property will be automatically set to `memory`.
 
 #### DuckDB Extensions, Settings, and Filesystems
 
@@ -120,6 +124,50 @@ as `yet_another` instead of `another`.) Note that these additional databases do 
 DuckDB `0.7.0` ships with support for reading and writing from attached SQLite databases. You can indicate the type of the database you are connecting to via the `type` argument,
 which currently supports `duckdb` and `sqlite`.
 
+#### Configuring dbt-duckdb Plugins
+
+dbt-duckdb has its own [plugin](dbt/adapters/duckdb/plugins/__init__.py) system to enable advanced users to extend
+dbt-duckdb with additional functionality, including:
+
+* Defining [custom Python UDFs](https://duckdb.org/docs/api/python/function.html) on the DuckDB database connection
+so that they can be used in your SQL models
+* Loading source data from [Excel](dbt/adapters/duckdb/plugins/excel.py), [Google Sheets](dbt/adapters/duckdb/plugins/gsheet.py), or [SQLAlchemy](dbt/adapters/duckdb/plugins/sqlalchemy.py) tables
+
+You can find more details on [how to write your own plugins here](#writing-your-own-plugins). To configure a plugin for use
+in your dbt project, use the `plugins` property on the profile:
+
+```
+default:
+  outputs:
+    dev:
+      type: duckdb
+      path: /tmp/dbt.duckdb
+      plugins:
+        - module: gsheet
+          config:
+            method: oauth
+        - module: sqlalchemy
+          alias: sql
+          config:
+            connection_url: "{{ env_var('DBT_ENV_SECRET_SQLALCHEMY_URI') }}"
+        - module: path.to.custom_udf_module
+```
+
+Every plugin must have a `module` property that indicates where the `Plugin` class to load is defined. Values of
+the `module` property that do not contain a "." are assumed to be one of the built-in plugins that are defined in
+[dbt.adapters.duckdb.plugins](dbt/adapters/duckdb/plugins/), while any values that do contain a "." are assumed to
+be user-defined modules that are visible on the Python path. Each plugin instance has a name for logging and reference
+purposes that defaults to the name of the module, but that may be overridden by the user by setting the `alias`
+property. Finally, modules may be initialized using an arbitrary set of key-value pairs that are defined in the
+`config` dictionary. In this example, we initialize the `gsheet` plugin with the setting `method: oauth` and we
+initialize the `sqlalchemy` plugin (aliased as "sql") with a `connection_url` that is set via an environment variable.
+
+Please remember that using plugins may require you to add additional dependencies to the Python environment that your dbt-duckdb pipeline runs in:
+
+* `excel` depends on `pandas`
+* `gsheet` depends on `gspread` and `pandas`
+*  `iceberg` depends on `pyiceberg` and Python >= 3.8
+* `sqlalchemy` depends on `pandas`, `sqlalchemy`, and the driver(s) you need
 
 ### Reading and Writing External Files
 
@@ -251,6 +299,26 @@ The value of the `dbt.ref` and `dbt.source` functions inside of a Python model w
 object that can be easily converted into a Pandas/Polars DataFrame or an Arrow table. The return value of the `model` function can be
 any Python object that DuckDB knows how to turn into a table, including a Pandas/Polars `DataFrame`, a DuckDB `Relation`, or an Arrow `Table`,
 `Dataset`, `RecordBatchReader`, or `Scanner`.
+
+### Writing Your Own Plugins
+
+Defining your own dbt-duckdb plugin is as simple as creating a python module that defines a class named `Plugin` that
+inherits from [dbt.adapters.duckdb.plugins.BasePlugin](dbt/adapters/duckdb/plugins/__init__.py). There are currently
+three methods that may be implemented in your Plugin class:
+
+1. `initialize`: Takes in the `config` dictionary for the plugin that is defined in the profile to enable any
+additional configuration for the module based on the project; this method is called once when an instance of the
+`Plugin` class is created.
+1. `configure_connection`: Takes an instance of the `DuckDBPyConnection` object used to connect to the DuckDB
+database and may perform any additional configuration of that object that is needed by the plugin, like defining
+custom user-defined functions.
+1. `load`: Takes a [SourceConfig](dbt/adapters/duckdb/utils.py) instance, which encapsulates the configuration for a
+a dbt source and can optionally return a DataFrame-like object that DuckDB knows how to turn into a table (this is 
+similar to a dbt-duckdb Python model, but without the ability to `ref` any models or access any information beyond
+the source config.)
+
+dbt-duckdb ships with a number of [built-in plugins](dbt/adapters/duckdb/plugins/) that can be used as examples
+for implementing your own.
 
 ### Roadmap
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ additional configuration for the module based on the project; this method is cal
 database and may perform any additional configuration of that object that is needed by the plugin, like defining
 custom user-defined functions.
 1. `load`: Takes a [SourceConfig](dbt/adapters/duckdb/utils.py) instance, which encapsulates the configuration for a
-a dbt source and can optionally return a DataFrame-like object that DuckDB knows how to turn into a table (this is 
+a dbt source and can optionally return a DataFrame-like object that DuckDB knows how to turn into a table (this is
 similar to a dbt-duckdb Python model, but without the ability to `ref` any models or access any information beyond
 the source config.)
 

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -47,13 +47,9 @@ class Attachment(dbtClassMixin):
 
 @dataclass
 class PluginConfig(dbtClassMixin):
-    # The name that this plugin will be referred to by in sources/models; must
-    # be unique within the project
-    name: str
+    module: str
 
-    # The fully-specified class name of the plugin code to use, which must be a
-    # subclass of dbt.adapters.duckdb.plugins.Plugin.
-    impl: str
+    alias: Optional[str] = None
 
     # A plugin-specific set of configuration options
     config: Optional[Dict[str, Any]] = None

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -58,7 +58,7 @@ class LocalEnvironment(Environment):
         # Extensions/settings need to be configured per cursor
         with self.lock:
             if self.conn is None:
-                self.conn = self.initialize_db(self.creds)
+                self.conn = self.initialize_db(self.creds, self._plugins)
             self.handle_count += 1
         cursor = self.initialize_cursor(self.creds, self.conn.cursor())
         return DuckDBConnectionWrapper(cursor, self)

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -3,6 +3,7 @@ import importlib
 from typing import Any
 from typing import Dict
 
+from duckdb import DuckDBPyConnection
 from ..utils import SourceConfig
 from dbt.dataclass_schema import dbtClassMixin
 
@@ -30,10 +31,12 @@ class Plugin(abc.ABC):
             raise TypeError(f"{impl} is not a subclass of Plugin")
         return Class(config)
 
-    @abc.abstractmethod
-    def __init__(self, plugin_config: Dict):
+    def __init__(self, name: str, plugin_config: Dict):
+        self.name = name
+
+    def configure_connection(self, conn: DuckDBPyConnection):
         pass
 
-    def load(self, source_config: SourceConfig):
+    def load_source(self, source_config: SourceConfig):
         """Load data from a source config and return it as a DataFrame-like object that DuckDB can read."""
         raise NotImplementedError

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -16,31 +16,90 @@ class PluginConfig(dbtClassMixin):
 
 
 class BasePlugin:
+    """
+    BasePlugin is the base class for creating plugins. A plugin can be created
+    from a module name, an optional configuration, and an alias. Each plugin
+    contains a name and its configuration.
+    """
+
     @classmethod
     def create(
-        cls, module: str, *, config: Optional[Dict[str, Any]] = None, alias: Optional[str] = None
+        cls,
+        module: str,
+        *,
+        config: Optional[Dict[str, Any]] = None,
+        alias: Optional[str] = None,
     ) -> "BasePlugin":
-        """Create a plugin from a module name and optional configuration."""
+        """
+        Create a plugin from a module name and optional configuration.
+
+        :param module: A string representing the module name.
+        :param config: An optional dictionary with configuration parameters.
+        :param alias: An optional string representing the alias name of the module.
+        :return: A Plugin instance.
+        :raises ImportError: If the module cannot be imported.
+        """
+        if not isinstance(module, str):
+            raise TypeError("Module name must be a string.")
+
         if "." not in module:
+            # if the module does not have a dot, assume it is a builtin
+            # plugin module and prepend the path name
             name = module
             module = f"dbt.adapters.duckdb.plugins.{module}"
         else:
             name = module.split(".")[-1]
-        mod = importlib.import_module(module)
-        return mod.Plugin(alias or name, config or {})
+
+        try:
+            mod = importlib.import_module(module)
+        except ImportError:
+            raise ImportError(f"Unable to import module '{module}'.")
+
+        if not hasattr(mod, "Plugin"):
+            raise ImportError(f"Module '{module}' does not have a Plugin class.")
+        else:
+            return mod.Plugin(alias or name, config or {})
 
     def __init__(self, name: str, plugin_config: Dict[str, Any]):
+        """
+        Initialize the BasePlugin instance with a name and its configuration.
+        This method should *not* be overriden by subclasses in general; any
+        initialization required from the configuration dictionary should be
+        defined in the `initialize` method.
+
+        :param name: A string representing the plugin name.
+        :param plugin_config: A dictionary representing the plugin configuration.
+        """
         self.name = name
         self.initialize(plugin_config)
 
     def initialize(self, plugin_config: Dict[str, Any]):
-        """Initialize the plugin with its configuration dictionary."""
+        """
+        Initialize the plugin with its configuration dictionary specified in the
+        profile. This function may be overridden by subclasses that have
+        additional initialization steps.
+
+        :param plugin_config: A dictionary representing the plugin configuration.
+        """
         pass
 
     def configure_connection(self, conn: DuckDBPyConnection):
-        """Configure the DuckDB connection with any necessary extensions and/or settings."""
+        """
+        Configure the DuckDB connection with any necessary extensions and/or settings.
+        This method should be overridden by subclasses to provide additional
+        configuration needed on the connection, such as user-defined functions.
+
+        :param conn: A DuckDBPyConnection instance to be configured.
+        """
         pass
 
     def load(self, source_config: SourceConfig):
-        """Load data from a source config and return it as a DataFrame-like object that DuckDB can read."""
-        raise NotImplementedError(f"load_source not implemented for {self.name}")
+        """
+        Load data from a source config and return it as a DataFrame-like object
+        that DuckDB can read. This method should be overridden by subclasses that
+        support loading data from a source config.
+
+        :param source_config: A SourceConfig instance representing the source data.
+        :raises NotImplementedError: If this method is not implemented by a subclass.
+        """
+        raise NotImplementedError(f"load method not implemented for {self.name}")

--- a/dbt/adapters/duckdb/plugins/excel.py
+++ b/dbt/adapters/duckdb/plugins/excel.py
@@ -1,16 +1,12 @@
 import pathlib
-from typing import Dict
 
 import pandas as pd
 
-from . import Plugin
+from . import BasePlugin
 from ..utils import SourceConfig
 
 
-class ExcelPlugin(Plugin):
-    def __init__(self, config: Dict):
-        self._config = config
-
+class Plugin(BasePlugin):
     def load(self, source_config: SourceConfig):
         ext_location = source_config.meta["external_location"]
         ext_location = ext_location.format(**source_config.as_dict())

--- a/dbt/adapters/duckdb/plugins/gsheet.py
+++ b/dbt/adapters/duckdb/plugins/gsheet.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
+from typing import Any
 from typing import Dict
 from typing import Literal
 
 import gspread
 import pandas as pd
 
-from . import Plugin
+from . import BasePlugin
 from . import PluginConfig
 from ..utils import SourceConfig
 
@@ -21,8 +22,8 @@ class GSheetConfig(PluginConfig):
             return gspread.oauth()
 
 
-class GSheetPlugin(Plugin):
-    def __init__(self, config: Dict):
+class Plugin(BasePlugin):
+    def initialize(self, config: Dict[str, Any]):
         self._config = GSheetConfig.from_dict(config)
         self._gc = self._config.client()
 

--- a/dbt/adapters/duckdb/plugins/iceberg.py
+++ b/dbt/adapters/duckdb/plugins/iceberg.py
@@ -1,13 +1,14 @@
+from typing import Any
 from typing import Dict
 
 import pyiceberg.catalog
 
-from . import Plugin
+from . import BasePlugin
 from ..utils import SourceConfig
 
 
-class IcebergPlugin(Plugin):
-    def __init__(self, config: Dict):
+class Plugin(BasePlugin):
+    def initialize(self, config: Dict[str, Any]):
         if "catalog" not in config:
             raise Exception("'catalog' is a required argument for the iceberg plugin!")
         catalog = config.pop("catalog")

--- a/dbt/adapters/duckdb/plugins/sqlalchemy.py
+++ b/dbt/adapters/duckdb/plugins/sqlalchemy.py
@@ -5,12 +5,12 @@ import pandas as pd
 from sqlalchemy import create_engine
 from sqlalchemy import text
 
-from . import Plugin
+from . import BasePlugin
 from ..utils import SourceConfig
 
 
-class SQLAlchemyPlugin(Plugin):
-    def __init__(self, plugin_config: Dict[str, Any]):
+class Plugin(BasePlugin):
+    def initialize(self, plugin_config: Dict[str, Any]):
         self.engine = create_engine(plugin_config["connection_url"])
 
     def load(self, source_config: SourceConfig) -> pd.DataFrame:

--- a/tests/create_function_plugin.py
+++ b/tests/create_function_plugin.py
@@ -1,0 +1,12 @@
+from duckdb import DuckDBPyConnection
+
+from dbt.adapters.duckdb.plugins import BasePlugin
+
+
+def foo() -> int:
+    return 1729
+
+
+class Plugin(BasePlugin):
+    def configure_connection(self, conn: DuckDBPyConnection):
+        conn.create_function("foo", foo)

--- a/tests/functional/plugins/test_gsheet.py
+++ b/tests/functional/plugins/test_gsheet.py
@@ -48,7 +48,7 @@ class TestGSheetPlugin:
                         "type": "duckdb",
                         "path": dbt_profile_target["path"],
                         "plugins": [
-                            {"name": "gsheet", "impl": "gsheet", "config": config}
+                            {"module": "gsheet", "config": config}
                         ],
                     }
                 },

--- a/tests/functional/plugins/test_iceberg.py
+++ b/tests/functional/plugins/test_iceberg.py
@@ -10,8 +10,8 @@ version: 2
 sources:
   - name: iceberg_source
     schema: main
-    meta:
-      plugin: icee
+    config:
+      plugin: iceberg
       iceberg_table: "examples.{identifier}"
     tables:
       - name: nyc_taxi_locations
@@ -40,7 +40,7 @@ class TestIcebergPlugin:
                         "type": "duckdb",
                         "path": dbt_profile_target["path"],
                         "plugins": [
-                            {"name": "icee", "impl": "iceberg", "config": config}
+                            {"module": "iceberg", "config": config}
                         ],
                     }
                 },

--- a/tests/functional/plugins/test_plugins.py
+++ b/tests/functional/plugins/test_plugins.py
@@ -75,8 +75,8 @@ class TestPlugins:
     def profiles_config_update(self, dbt_profile_target, sqlite_test_db):
         config = {"connection_url": f"sqlite:///{sqlite_test_db}"}
         plugins = [
-            {"name": "excel", "impl": "excel"},
-            {"name": "sql", "impl": "sqlalchemy", "config": config},
+            {"module": "excel"},
+            {"module": "sqlalchemy", "alias": "sql", "config": config},
         ]
 
         return {

--- a/tests/functional/plugins/test_plugins.py
+++ b/tests/functional/plugins/test_plugins.py
@@ -51,6 +51,9 @@ sqlalchemy1_sql = """
 sqlalchemy2_sql = """
     select * from {{ source('sql_source', 'tt2') }}
 """
+foo_sql = """
+    select foo() as foo
+"""
 
 
 @pytest.mark.skip_profile("buenavista")
@@ -77,6 +80,7 @@ class TestPlugins:
         plugins = [
             {"module": "excel"},
             {"module": "sqlalchemy", "alias": "sql", "config": config},
+            {"module": "tests.create_function_plugin"},
         ]
 
         return {
@@ -100,11 +104,12 @@ class TestPlugins:
             "excel.sql": excel1_sql,
             "sqlalchemy1.sql": sqlalchemy1_sql,
             "sqlalchemy2.sql": sqlalchemy2_sql,
+            "foo.sql": foo_sql,
         }
 
     def test_plugins(self, project):
         results = run_dbt()
-        assert len(results) == 3
+        assert len(results) == 4
 
         res = project.run_sql("SELECT COUNT(1) FROM excel_file", fetch="one")
         assert res[0] == 9
@@ -136,3 +141,6 @@ class TestPlugins:
                 "sqlalchemy2",
             ],
         )
+
+        res = project.run_sql("SELECT foo FROM foo", fetch="one")
+        assert res[0] == 1729


### PR DESCRIPTION
Fixes #170 in that it will let users wire up their own plugins for creating user-defined functions on the DuckDB instance in Python and will hopefully let us extend stuff in some more cool directions in the future.

Going to add some more docs to this tomorrow, but posting it for feedback now.