### PR TITLE
Some fixes for catalog lookups in a multi-database, multi-schema world

### DIFF
--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -96,7 +96,7 @@ class TestEmptyPythonModel:
         run_dbt(["run"])
         result = project.run_sql(
             f"""
-            select column_name, data_type from information_schema.columns 
+            select column_name, data_type from system.information_schema.columns
             where table_name='upstream_model' order by column_name
             """,
             fetch="all",


### PR DESCRIPTION
Ensure that we are always looking for the relations we need to find in as specific a way as possible (so ideally, database + schema + identifier whenever all 3 fields are available to use and supported by the version of DuckDB that we're running.)