### PR TITLE
Create a simple plugin system for writing data to external destinations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 *,cover
 .hypothesis/
 test.env
+.mypy_cache/
 
 # Translations
 *.mo

--- a/dbt/adapters/duckdb/environments/buenavista.py
+++ b/dbt/adapters/duckdb/environments/buenavista.py
@@ -60,3 +60,17 @@ class BVEnvironment(Environment):
         cursor.execute(json.dumps(payload))
         cursor.close()
         handle.close()
+
+    def store_relation(self, plugin_name: str, target_config: utils.TargetConfig) -> None:
+        handle = self.handle()
+        payload = {
+            "method": "dbt_store_relation",
+            "params": {
+                "plugin_name": plugin_name,
+                "source_config": target_config.as_dict(),
+            },
+        }
+        cursor = handle.cursor()
+        cursor.execute(json.dumps(payload))
+        cursor.close()
+        handle.close()

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,4 +1,6 @@
 import os
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -11,8 +13,8 @@ from dbt.adapters.base.column import Column
 from dbt.adapters.base.impl import ConstraintSupport
 from dbt.adapters.base.meta import available
 from dbt.adapters.duckdb.connections import DuckDBConnectionManager
-from dbt.adapters.duckdb.glue import create_or_update_table
 from dbt.adapters.duckdb.relation import DuckDBRelation
+from dbt.adapters.duckdb.utils import TargetConfig
 from dbt.adapters.sql import SQLAdapter
 from dbt.contracts.connection import AdapterResponse
 from dbt.contracts.graph.nodes import ColumnLevelConstraint
@@ -73,22 +75,23 @@ class DuckDBAdapter(SQLAdapter):
             return False
 
     @available
-    def register_glue_table(
+    def store_relation(
         self,
-        glue_database: str,
-        table: str,
+        plugin_name: str,
+        relation: DuckDBRelation,
         column_list: Sequence[Column],
-        location: str,
-        file_format: str,
+        config: Dict[str, Any],
+        path: Optional[str] = None,
+        format: Optional[str] = None,
     ) -> None:
-        create_or_update_table(
-            database=glue_database,
-            table=table,
+        target_config = TargetConfig(
+            relation=relation,
             column_list=column_list,
-            s3_path=location,
-            file_format=file_format,
-            settings=self.config.credentials.settings,
+            config=config,
+            path=path,
+            format=format,
         )
+        DuckDBConnectionManager.env().store_relation(plugin_name, target_config)
 
     @available
     def external_root(self) -> str:

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional
 from duckdb import DuckDBPyConnection
 
 from ..utils import SourceConfig
+from ..utils import TargetConfig
 from dbt.dataclass_schema import dbtClassMixin
 
 
@@ -103,3 +104,6 @@ class BasePlugin:
         :raises NotImplementedError: If this method is not implemented by a subclass.
         """
         raise NotImplementedError(f"load method not implemented for {self.name}")
+
+    def store(self, target_config: TargetConfig):
+        raise NotImplementedError(f"store method not implemented for {self.name}")

--- a/dbt/adapters/duckdb/plugins/excel.py
+++ b/dbt/adapters/duckdb/plugins/excel.py
@@ -8,8 +8,8 @@ from ..utils import SourceConfig
 
 class Plugin(BasePlugin):
     def load(self, source_config: SourceConfig):
-        ext_location = source_config.meta["external_location"]
+        ext_location = source_config["external_location"]
         ext_location = ext_location.format(**source_config.as_dict())
         source_location = pathlib.Path(ext_location.strip("'"))
-        sheet_name = source_config.meta.get("sheet_name", 0)
+        sheet_name = source_config.get("sheet_name", 0)
         return pd.read_excel(source_location, sheet_name=sheet_name)

--- a/dbt/adapters/duckdb/plugins/gsheet.py
+++ b/dbt/adapters/duckdb/plugins/gsheet.py
@@ -29,18 +29,18 @@ class Plugin(BasePlugin):
 
     def load(self, source_config: SourceConfig):
         doc = None
-        if "title" in source_config.meta:
-            doc = self._gc.open(source_config.meta["title"])
-        elif "key" in source_config.meta:
-            doc = self._gc.open_by_key(source_config.meta["key"])
-        elif "url" in source_config.meta:
-            doc = self._gc.open_by_url(source_config.meta["url"])
+        if "title" in source_config:
+            doc = self._gc.open(source_config["title"])
+        elif "key" in source_config:
+            doc = self._gc.open_by_key(source_config["key"])
+        elif "url" in source_config:
+            doc = self._gc.open_by_url(source_config["url"])
         else:
             raise Exception("Source config did not indicate a method to open a GSheet to read")
 
         sheet = None
-        if "worksheet" in source_config.meta:
-            work_id = source_config.meta["worksheet"]
+        if "worksheet" in source_config:
+            work_id = source_config["worksheet"]
             if isinstance(work_id, int):
                 sheet = doc.get_worksheet(work_id)
             elif isinstance(work_id, str):

--- a/dbt/adapters/duckdb/plugins/iceberg.py
+++ b/dbt/adapters/duckdb/plugins/iceberg.py
@@ -15,7 +15,7 @@ class Plugin(BasePlugin):
         self._catalog = pyiceberg.catalog.load_catalog(catalog, **config)
 
     def load(self, source_config: SourceConfig):
-        table_format = source_config.meta.get("iceberg_table", "{schema}.{identifier}")
+        table_format = source_config.get("iceberg_table", "{schema}.{identifier}")
         table_name = table_format.format(**source_config.as_dict())
         table = self._catalog.load_table(table_name)
         scan_keys = {
@@ -26,5 +26,5 @@ class Plugin(BasePlugin):
             "options",
             "limit",
         }
-        scan_config = {k: source_config.meta[k] for k in scan_keys if k in source_config.meta}
+        scan_config = {k: source_config[k] for k in scan_keys if k in source_config}
         return table.scan(**scan_config).to_arrow()

--- a/dbt/adapters/duckdb/plugins/sqlalchemy.py
+++ b/dbt/adapters/duckdb/plugins/sqlalchemy.py
@@ -14,15 +14,15 @@ class Plugin(BasePlugin):
         self.engine = create_engine(plugin_config["connection_url"])
 
     def load(self, source_config: SourceConfig) -> pd.DataFrame:
-        if "query" in source_config.meta:
-            query = source_config.meta["query"]
+        if "query" in source_config:
+            query = source_config["query"]
             query = query.format(**source_config.as_dict())
-            params = source_config.meta.get("params", {})
+            params = source_config.get("params", {})
             with self.engine.connect() as conn:
                 return pd.read_sql_query(text(query), con=conn, params=params)
         else:
-            if "table" in source_config.meta:
-                table = source_config.meta["table"]
+            if "table" in source_config:
+                table = source_config["table"]
             else:
                 table = source_config.table_name()
             with self.engine.connect() as conn:

--- a/dbt/adapters/duckdb/relation.py
+++ b/dbt/adapters/duckdb/relation.py
@@ -16,22 +16,20 @@ class DuckDBRelation(BaseRelation):
 
     @classmethod
     def create_from_source(cls: Type[Self], source: SourceDefinition, **kwargs: Any) -> Self:
-        source_config = SourceConfig.create(source)
+        source_config = SourceConfig.create_from_source(source)
         # First check to see if a 'plugin' is defined in the meta argument for
         # the source or its parent configuration, and if it is, use the environment
         # associated with this run to get the name of the source that we should
         # reference in the compiled model
-        if "plugin" in source_config.meta:
-            plugin_name = source_config.meta["plugin"]
+        if "plugin" in source_config:
+            plugin_name = source_config["plugin"]
             DuckDBConnectionManager.env().load_source(plugin_name, source_config)
         elif "external_location" in source_config.meta:
             # Call str.format with the schema, name and identifier for the source so that they
             # can be injected into the string; this helps reduce boilerplate when all
             # of the tables in the source have a similar location based on their name
             # and/or identifier.
-            ext_location = source_config.meta["external_location"].format(
-                **source_config.as_dict()
-            )
+            ext_location = source_config["external_location"].format(**source_config.as_dict())
             # If it's a function call or already has single quotes, don't add them
             if "(" not in ext_location and not ext_location.startswith("'"):
                 ext_location = f"'{ext_location}'"

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -2,7 +2,10 @@ from dataclasses import dataclass
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Sequence
 
+from dbt.adapters.base.column import Column
+from dbt.adapters.base.relation import BaseRelation
 from dbt.contracts.graph.nodes import SourceDefinition
 
 
@@ -52,3 +55,33 @@ class SourceConfig:
             database=source.database,
             meta=meta,
         )
+
+
+@dataclass
+class TargetConfig:
+    relation: BaseRelation
+    column_list: Sequence[Column]
+    config: Dict[str, Any]
+    path: Optional[str] = None
+    format: Optional[str] = None
+
+    def get(self, key, default=None):
+        return self.config.get(key, default)
+
+    def __getitem__(self, key):
+        return self.config[key]
+
+    def __contains__(self, key):
+        return key in self.settings
+
+    def as_dict(self) -> Dict[str, Any]:
+        base = {
+            "relation": self.relation.to_dict(),
+            "column_list": [{"column": c.column, "dtype": c.dtype} for c in self.column_list],
+            "config": self.config,
+        }
+        if self.path:
+            base["path"] = self.path
+        if self.format:
+            base["format"] = self.format
+        return base

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -14,6 +14,15 @@ class SourceConfig:
     database: Optional[str]
     meta: Dict[str, Any]
 
+    def get(self, key, default=None):
+        return self.meta.get(key, default)
+
+    def __getitem__(self, key):
+        return self.meta[key]
+
+    def __contains__(self, key):
+        return key in self.meta
+
     def table_name(self) -> str:
         if self.database:
             return ".".join([self.database, self.schema, self.identifier])
@@ -31,7 +40,7 @@ class SourceConfig:
         return base
 
     @classmethod
-    def create(cls, source: SourceDefinition) -> "SourceConfig":
+    def create_from_source(cls, source: SourceDefinition) -> "SourceConfig":
         meta = source.source_meta.copy()
         meta.update(source.meta)
         # Use the config properties as well if they are present

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -213,11 +213,9 @@ def materialize(df, con):
   {%- endcall %}
 {% endmacro %}
 
-{% macro register_glue_table(register, glue_database, relation, location, format) -%}
-  {% if location.startswith("s3://") and register == true %}
-    {%- set column_list = adapter.get_columns_in_relation(relation) -%}
-    {% do adapter.register_glue_table(glue_database, relation.identifier, column_list, location, format) %}
-  {% endif %}
+{% macro store_relation(plugin, relation, location, format) -%}
+  {%- set column_list = adapter.get_columns_in_relation(relation) -%}
+  {% do adapter.store_relation(relation, column_list, location, format) %}
 {% endmacro %}
 
 {% macro render_write_options(config) -%}

--- a/dbt/include/duckdb/macros/materializations/external.sql
+++ b/dbt/include/duckdb/macros/materializations/external.sql
@@ -76,9 +76,14 @@
   {{ drop_relation_if_exists(temp_relation) }}
 
   -- register table into glue
+  {%- set plugin_name = config.get('plugin') -%}
   {%- set glue_register = config.get('glue_register', default=false) -%}
-  {%- set glue_database = render(config.get('glue_database', default='default')) -%}
-  {% do register_glue_table(glue_register, glue_database, target_relation, location, format) %}
+  {% if plugin_name is not none or glue_register is true %}
+    {% if glue_register %}
+      {%- set plugin_name = 'glue' -%}
+    {% endif %}
+    {% do store_relation(plugin_name, target_relation, location, format) %}
+  {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 

--- a/tests/unit/test_glue.py
+++ b/tests/unit/test_glue.py
@@ -3,7 +3,7 @@ from unittest.mock import call
 import pytest
 
 from dbt.adapters.base.column import Column
-from dbt.adapters.duckdb.glue import create_or_update_table
+from dbt.adapters.duckdb.plugins.glue import create_or_update_table
 
 
 class TestGlue:
@@ -51,9 +51,10 @@ class TestGlue:
         ]
 
     def test_create_glue_table(self, mocker, columns):
-        boto3 = mocker.patch("dbt.adapters.duckdb.glue.boto3.client")
-        boto3.return_value.get_table.return_value = None
+        client = mocker.Mock()
+        client.get_table.return_value = None
         create_or_update_table(
+            client,
             database="test",
             table="test",
             column_list=columns,
@@ -62,11 +63,10 @@ class TestGlue:
             settings=None,
         )
 
-        boto3.assert_has_calls(
+        client.assert_has_calls(
             [
-                call("glue"),
-                call().get_table(DatabaseName="test", Name="test"),
-                call().create_table(
+                call.get_table(DatabaseName="test", Name="test"),
+                call.create_table(
                     DatabaseName="test",
                     TableInput={
                         "Name": "test",
@@ -132,8 +132,8 @@ class TestGlue:
         )
 
     def test_update_glue_table(self, mocker, columns):
-        boto3 = mocker.patch("dbt.adapters.duckdb.glue.boto3.client")
-        boto3.return_value.get_table.return_value = {
+        client = mocker.Mock()
+        client.get_table.return_value = {
             "Table": {
                 "Name": "test",
                 "TableType": "EXTERNAL_TABLE",
@@ -158,6 +158,7 @@ class TestGlue:
             },
         }
         create_or_update_table(
+            client,
             database="test",
             table="test",
             column_list=columns,
@@ -165,11 +166,10 @@ class TestGlue:
             file_format="parquet",
             settings=None,
         )
-        boto3.assert_has_calls(
+        client.assert_has_calls(
             [
-                call("glue"),
-                call().get_table(DatabaseName="test", Name="test"),
-                call().update_table(
+                call.get_table(DatabaseName="test", Name="test"),
+                call.update_table(
                     DatabaseName="test",
                     TableInput={
                         "Name": "test",
@@ -235,8 +235,8 @@ class TestGlue:
         )
 
     def test_without_update_glue_table(self, mocker, columns):
-        boto3 = mocker.patch("dbt.adapters.duckdb.glue.boto3.client")
-        boto3.return_value.get_table.return_value = {
+        client = mocker.Mock()
+        client.get_table.return_value = {
             "Table": {
                 "Name": "test",
                 "TableType": "EXTERNAL_TABLE",
@@ -300,6 +300,7 @@ class TestGlue:
             },
         }
         create_or_update_table(
+            client,
             database="test",
             table="test",
             column_list=columns,
@@ -307,5 +308,7 @@ class TestGlue:
             file_format="parquet",
             settings=None,
         )
-        assert len(boto3.mock_calls) == 2
-        boto3.has_calls([call("glue"), call().get_table(DatabaseName="test", Name="test")])
+        assert len(client.mock_calls) == 1
+        client.has_calls(
+            [call.get_table(DatabaseName="test", Name="test")]
+        )


### PR DESCRIPTION
Fixes #143

This implements a write-side plugin system that can run after a relation is materialized (either in DuckDB or externally) and can be used to take some action on the resulting data. I'm starting out by porting the Glue database stuff (which can persist an output parquet file as a relation in the AWS Glue catalog) to guide the implementation of the plugins to act as a dual to the source-side plugins.

One rub here is that I don't have a good functional test of the glue stuff, so I'm going to create one in a separate PR that runs against the existing glue impl, merge it, and then port the impl over to confirm that it will work against my new impl here (and likely fix the bugs I find in the process.)