### PR TITLE
Prevent loading source data via plugin during dbt parsing phase

### DIFF
--- a/dbt/adapters/duckdb/relation.py
+++ b/dbt/adapters/duckdb/relation.py
@@ -23,7 +23,9 @@ class DuckDBRelation(BaseRelation):
         # reference in the compiled model
         if "plugin" in source_config:
             plugin_name = source_config["plugin"]
-            DuckDBConnectionManager.env().load_source(plugin_name, source_config)
+            if DuckDBConnectionManager._ENV is not None:
+                # No connection means we are probably in the dbt parsing phase, so don't load yet.
+                DuckDBConnectionManager.env().load_source(plugin_name, source_config)
         elif "external_location" in source_config.meta:
             # Call str.format with the schema, name and identifier for the source so that they
             # can be injected into the string; this helps reduce boilerplate when all


### PR DESCRIPTION
During parsing phase (e.g. in `dbt compile`) `dbt` initially does not have an active connection.

We fix `DuckDBRelation.create_from_source` to not attempt to load in the source data in this case.

Fixes https://github.com/jwills/dbt-duckdb/issues/176