### PR TITLE
Simplify extension loading in dbt-duckdb

### DIFF
--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -65,7 +65,8 @@ class Environment(abc.ABC):
         # install any extensions on the connection
         if creds.extensions is not None:
             for extension in creds.extensions:
-                conn.execute(f"INSTALL '{extension}'")
+                conn.install_extension(extension)
+                conn.load_extension(extension)
 
         # Attach any fsspec filesystems on the database
         if creds.filesystems:
@@ -92,9 +93,6 @@ class Environment(abc.ABC):
 
     @classmethod
     def initialize_cursor(cls, creds: DuckDBCredentials, cursor):
-        # Extensions/settings need to be configured per cursor
-        for ext in creds.extensions or []:
-            cursor.execute(f"LOAD '{ext}'")
         for key, value in creds.load_settings().items():
             # Okay to set these as strings because DuckDB will cast them
             # to the correct type


### PR DESCRIPTION
Fixes #179 

In the old code, we would re-load any DuckDB extensions that we needed for the config in the connection that we used for each dbt thread. This was generally fine in that loading an already-loaded DuckDB extension is idempotent-- _except_ when it wasn't, due to some sort of bug (as in #179).

The good news though is that this extension reloading is unnecessary now, and since we're pinning ourselves to post 0.5.0 versions of DuckDB, we can also switch to using the more python `install_extension` and `load_extension` methods on the DuckDB connection in order to load the extensions once per run, instead of on each thread.