### PR TITLE
Updates to support a broader class of incremental functionality

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -195,14 +195,6 @@ def materialize(df, con):
   {% do return(get_incremental_delete_insert_sql(arg_dict)) %}
 {% endmacro %}
 
-{% macro duckdb__get_incremental_delete_insert_sql(arg_dict) %}
-  {% do return(get_delete_insert_merge_sql(arg_dict["target_relation"].include(database=adapter.use_database()), arg_dict["temp_relation"], arg_dict["unique_key"], arg_dict["dest_columns"])) %}
-{% endmacro %}
-
-{% macro duckdb__get_incremental_append_sql(arg_dict) %}
-  {% do return(get_insert_into_sql(arg_dict["target_relation"].include(database=adapter.use_database()), arg_dict["temp_relation"], arg_dict["dest_columns"])) %}
-{% endmacro %}
-
 {% macro location_exists(location) -%}
   {% do return(adapter.location_exists(location)) %}
 {% endmacro %}

--- a/dbt/include/duckdb/macros/columns.sql
+++ b/dbt/include/duckdb/macros/columns.sql
@@ -1,0 +1,23 @@
+{% macro duckdb__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
+
+  {% if add_columns %}
+    {% for column in add_columns %}
+      {% set sql -%}
+         alter {{ relation.type }} {{ relation }} add column
+           {{ column.name }} {{ column.data_type }}
+      {%- endset -%}
+      {% do run_query(sql) %}
+    {% endfor %}
+  {% endif %}
+
+  {% if remove_columns %}
+    {% for column in remove_columns %}
+      {% set sql -%}
+        alter {{ relation.type }} {{ relation }} drop column
+          {{ column.name }}
+      {%- endset -%}
+      {% do run_query(sql) %}
+    {% endfor %}
+  {% endif %}
+
+{% endmacro %}

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -58,9 +58,9 @@
 
     {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}
     {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}
-    {% set incremental_predicates = config.get('incremental_predicates', none) %}
+    {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}
     {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}
-    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'predicates': incremental_predicates }) %}
+    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}
     {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}
     {% set language = "sql" %}
 

--- a/tests/functional/adapter/test_incremental.py
+++ b/tests/functional/adapter/test_incremental.py
@@ -1,7 +1,21 @@
 from dbt.tests.adapter.incremental.test_incremental_unique_id import (
     BaseIncrementalUniqueKey,
 )
+from dbt.tests.adapter.incremental.test_incremental_predicates import (
+    BaseIncrementalPredicates,
+)
+from dbt.tests.adapter.incremental.test_incremental_on_schema_change import (
+    BaseIncrementalOnSchemaChange,
+)
 
 
-class TestBaseIncrementalUniqueKey(BaseIncrementalUniqueKey):
+class TestIncrementalUniqueKey(BaseIncrementalUniqueKey):
+    pass
+
+
+class TestIncrementalPredicates(BaseIncrementalPredicates):
+    pass
+
+
+class TestIncrementalOnSchemaChange(BaseIncrementalOnSchemaChange):
     pass


### PR DESCRIPTION
I noticed while working on the updates to support MotherDuck that our `incremental` support for both additional predicates and schema changes had gotten out-of-sync with the functionality provided by the other dbt adapters, so I did some work here to fix that up and include the dbt adapter tests to ensure it stays that way.