### PR TITLE
Add in plugins for the motherduck and postgres extensions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -348,6 +348,7 @@ jobs:
 
     env:
       TOXENV: "plugins"
+      MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
       PYTEST_ADDOPTS: "-v --color=yes --csv plugins_results.csv"
 
     steps:

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -53,8 +53,8 @@ class BasePlugin:
 
         try:
             mod = importlib.import_module(module)
-        except ImportError:
-            raise ImportError(f"Unable to import module '{module}'.")
+        except ImportError as e:
+            raise ImportError(f"Unable to import module '{module}': {e}")
 
         if not hasattr(mod, "Plugin"):
             raise ImportError(f"Module '{module}' does not have a Plugin class.")

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -1,0 +1,18 @@
+from typing import Any
+from typing import Dict
+
+from duckdb import DuckDBPyConnection
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    def initialize(self, config: Dict[str, Any]):
+        self._token = config.get("token")
+
+    def configure_connection(self, conn: DuckDBPyConnection):
+        conn.load_extension("motherduck")
+        connect_stmt = "PRAGMA md_connect()"
+        if self._token:
+            connect_stmt = f"PRAGMA md_connect('token={self._token}')"
+        conn.execute(connect_stmt)

--- a/dbt/adapters/duckdb/plugins/postgres.py
+++ b/dbt/adapters/duckdb/plugins/postgres.py
@@ -1,0 +1,35 @@
+from typing import Any
+from typing import Dict
+
+from duckdb import DuckDBPyConnection
+
+from . import BasePlugin
+
+
+class Plugin(BasePlugin):
+    def initialize(self, config: Dict[str, Any]):
+        self._dsn = config.get("dsn")
+        if self._dsn is None:
+            raise Exception("'dsn' is a required argument for the postgres plugin!")
+        self._source_schema = config.get("source_schema", "public")
+        self._sink_schema = config.get("sink_schema", "main")
+        self._overwrite = config.get("overwrite", False)
+        self._filter_pushdown = config.get("filter_pushdown", False)
+
+    def configure_connection(self, conn: DuckDBPyConnection):
+        conn.install_extension("postgres")
+        conn.load_extension("postgres")
+
+        if self._sink_schema:
+            conn.execute(f"CREATE SCHEMA IF NOT EXISTS {self._sink_schema}")
+
+        attach_args = [
+            ("source_schema", f"'{self._source_schema}'"),
+            ("sink_schema", f"'{self._sink_schema}'"),
+            ("overwrite", str(self._overwrite).lower()),
+            ("filter_pushdown", str(self._filter_pushdown).lower()),
+        ]
+        attach_stmt = (
+            f"CALL postgres_attach('{self._dsn}', {', '.join(f'{k}={v}' for k, v in attach_args)})"
+        )
+        conn.execute(attach_stmt)

--- a/dbt/adapters/duckdb/plugins/sqlalchemy.py
+++ b/dbt/adapters/duckdb/plugins/sqlalchemy.py
@@ -39,3 +39,4 @@ class Plugin(BasePlugin):
 
     def __del__(self):
         self.engine.dispose()
+        self.engine = None

--- a/tests/functional/plugins/test_postgres.py
+++ b/tests/functional/plugins/test_postgres.py
@@ -1,0 +1,44 @@
+import pytest
+
+from dbt.tests.util import (
+    check_relations_equal,
+    run_dbt,
+)
+
+
+# Skipping this b/c it requires running a properly setup Postgres server
+# when testing it locally and also b/c I think there is something
+# wrong with profiles_config_update since it can't be used in multiple
+# tests in the same pytest session
+#
+# Exercise locally with: pytest --profile=file tests/functional/plugins/test_postgres.py
+@pytest.mark.skip
+class TestPostgresPlugin:
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target):
+        config = {"dsn": "dbname=postgres", "sink_schema": "plugins", "overwrite": True}
+        if "path" not in dbt_profile_target:
+            return {}
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": dbt_profile_target["path"],
+                        "plugins": [{"module": "postgres", "config": config}],
+                    }
+                },
+                "target": "dev",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"pg_model.sql": "SELECT * FROM plugins.foo"}
+
+    def test_postgres_plugin(self, project):
+        results = run_dbt()
+        assert len(results) == 1
+
+        res = project.run_sql("SELECT SUM(i) FROM pg_model", fetch="one")
+        assert res[0] == 6

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
 description = adapter plugin testing
 skip_install = True
 passenv = *
-commands = {envpython} -m pytest {posargs} tests/functional/plugins
+commands = {envpython} -m pytest {posargs} --profile=file tests/functional/plugins
 deps =
   -rdev-requirements.txt
   -e.


### PR DESCRIPTION
Both of these extensions benefit from a bit of additional initialization logic that needs access to private (and thus `profiles.yml`-safe) config info.

1. For `postgres`, we likely want to do a `call postgres_attach` operation that uses a dsn string that main contain secrets (e.g. passwords),
2. For `motherduck`, we'll want to call `pragma md_connect` and possibly include the Motherduck token in the config (which again needs to be private.)