### PR TITLE
Add a keep_open option to the profile

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -117,6 +117,11 @@ class DuckDBCredentials(Credentials):
     # be as small as possible.
     disable_transactions: bool = False
 
+    # Whether to keep the DuckDB connection open between invocations of dbt
+    # (we do this automatically for in-memory or MD connections, but not for
+    # local DuckDB files, but this is a way to override that behavior)
+    keep_open: bool = False
+
     @classmethod
     def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
         if duckdb.__version__ >= "0.7.0":

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -48,7 +48,8 @@ class LocalEnvironment(Environment):
         self.handle_count = 0
         self.lock = threading.RLock()
         self._keep_open = (
-            credentials.path == ":memory:"
+            credentials.keep_open
+            or credentials.path == ":memory:"
             or credentials.path.startswith("md:")
             or credentials.path.startswith("motherduck:")
         )


### PR DESCRIPTION
Adding a way to replicate the "keep open" behavior that we use for in-memory and MotherDuck connections for local DuckDB files to see if that helps solve some weird issues folks are seeing running at scale on EC2 instances.