### PR TITLE
fix: remove parenthesis from md_connect call

### DIFF
--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -12,7 +12,7 @@ class Plugin(BasePlugin):
 
     def configure_connection(self, conn: DuckDBPyConnection):
         conn.load_extension("motherduck")
-        connect_stmt = "PRAGMA md_connect()"
+        connect_stmt = "PRAGMA md_connect"
         if self._token:
             connect_stmt = f"PRAGMA md_connect('token={self._token}')"
         conn.execute(connect_stmt)


### PR DESCRIPTION
![image](https://github.com/jwills/dbt-duckdb/assets/35972814/635c22ea-5042-40cd-b8aa-9da3130d5de3)

The syntax when `token` is specified is working as intended.
