### PR TITLE
Make source tags available to plugins through the SourceConfig

### DIFF
--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Sequence
 
@@ -16,6 +17,7 @@ class SourceConfig:
     schema: str
     database: Optional[str]
     meta: Dict[str, Any]
+    tags: List[str]
 
     def get(self, key, default=None):
         return self.meta.get(key, default)
@@ -38,6 +40,7 @@ class SourceConfig:
             "identifier": self.identifier,
             "schema": self.schema,
             "database": self.database,
+            "tags": self.tags,
         }
         base.update(self.meta)
         return base
@@ -54,6 +57,7 @@ class SourceConfig:
             schema=source.schema,
             database=source.database,
             meta=meta,
+            tags=source.tags or [],
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def dbt_profile_target(profile_type, bv_server_process, tmp_path_factory):
     return profile
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="class")
 def skip_by_profile_type(profile_type, request):
     if request.node.get_closest_marker("skip_profile"):
         for skip_profile_type in request.node.get_closest_marker("skip_profile").args:


### PR DESCRIPTION
I have a custom plugin where I'd like to use the source's tags to inform the plugin `load` method. This MR adds the source tags as an additional SourceConfig attribute.

Additionally, when attempting to ensure existing plugin tests passed, ran into the issue that tests that should be skipped when the test profile is not `md` would still load the motherduck plugin and attempt a connection. This is happening because any test classes using the dbt `project` fixture will execute it before the `skip_by_profile_type` fixture, as the former is at the higher class-level scope, thus rendering the `pytest.mark.skip_profile` decorator ineffectual

Fix: changed `skip_by_profile_type` autouse fixture from function to class scope.


