### PR TITLE
Add option to fetch Gsheet data using range

### DIFF
--- a/dbt/adapters/duckdb/plugins/gsheet.py
+++ b/dbt/adapters/duckdb/plugins/gsheet.py
@@ -52,4 +52,21 @@ class Plugin(BasePlugin):
         else:
             sheet = doc.sheet1
 
-        return pd.DataFrame(sheet.get_all_records())
+        if "range" in source_config:
+            range = source_config["range"]
+            df = pd.DataFrame(sheet.get(range))
+            if "headers" in source_config:
+                headers = source_config["headers"]
+                if len(headers) == len(df.columns):
+                    df.columns = headers
+                    return df
+                else:
+                    raise Exception(
+                        f"Number of configured headers ({len(headers)}) does not match number of columns in fetched range ({len(df.columns)})."
+                    )
+            else:
+                df.rename(columns=df.iloc[0]).drop(df.index[0]).reset_index(drop=True)
+                return df
+
+        else:
+            return pd.DataFrame(sheet.get_all_records())


### PR DESCRIPTION
Related to: #213 

Finally came around to make this PR to add the option to fetch Google Sheet data using a range instead of fetching the entire sheet. 

It works by calling `.get(range)` on the sheet instead of `.get_all_records()` if a range is provided.  Within the source .yml file, you have to add a range using the `range` key and, optional, headers under the `headers` key you want to use in case your selected range doesn't have any headers. 

```yml
version: 2

sources:
  - name: test_table
    schema: output
    meta:
      plugin: gsheet
      key: some_id_here
      worksheet: data
      range: A1:B2
      headers:
        - column_a
        - column_b
    tables:
      - name: test_table
```

Finally if you don't have a matching amount of headers and number of columns in the selected range, it will give a nice exception. For example, the below source .yml fetches 3 columns, but only 2 headers are provided. This will be caught by the exception.

```yml
version: 2

sources:
  - name: test_table
    schema: output
    meta:
      plugin: gsheet
      key: some_id_here
      worksheet: data
      range: A1:C2
      headers:
        - column_a
        - column_b
    tables:
      - name: test_table
```

